### PR TITLE
Update English for 5.0.1 pt.2

### DIFF
--- a/lang/english.xml
+++ b/lang/english.xml
@@ -99,6 +99,13 @@
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_BABYLON_DESCRIPTION" Language="en_US">
 			<Text>[ICON_TechBoosted] Eurekas provide 65% of the [ICON_SCIENCE] Science for technologies. Start the game with -50% [ICON_SCIENCE] Science per turn, but each researched technology grants +1% extra [ICON_SCIENCE] Science. Cannot receive additional Eureka bonus from Free Inquiry Golden Age dedication.</Text>
 		</Replace>
+		<!-- = leader ability = -->
+		<Replace Tag="LOC_TRAIT_LEADER_HAMMURABI_DESCRIPTION" Language="en_US">
+			<Text>When each specialty district is constructed for the first time receive the lowest [ICON_PRODUCTION] Production cost building that can currently be constructed in that district.</Text>
+		</Replace>
+		<Replace Tag="LOC_TRAIT_LEADER_HAMMURABI_XP1_DESCRIPTION" Language="en_US">
+			<Text>When each specialty district type except the Government Plaza is constructed for the first time receive the lowest [ICON_PRODUCTION] Production cost building that can currently be constructed in that district.</Text>
+		</Replace>
 
 		<!-- == BRAZIL == -->
 		<!-- = unique district = -->
@@ -842,10 +849,10 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_MISSION_DESCRIPTION" Language="en_US">
-			<Text>Unlocks the Builder ability to construct a Mission, unique to Spain.[NEWLINE][NEWLINE]+2 [ICON_Faith] Faith. +1 [ICON_Faith] Faith if built at least 10 tiles away from [ICON_CAPITAL] Capital, otherwise +1 [ICON_HOUSING] Housing.[NEWLINE][NEWLINE]+2 [ICON_Science] Science if built next to a Campus district. +2 Science at The Enlightenment. Cannot be built next to another Mission.</Text>
+			<Text>Unlocks the Builder ability to construct a Mission, unique to Spain.[NEWLINE][NEWLINE]+2 [ICON_Faith] Faith. +1 [ICON_Faith] Faith if built at least 8 tiles away from [ICON_CAPITAL] Capital, otherwise +1 [ICON_HOUSING] Housing.[NEWLINE][NEWLINE]+2 [ICON_Science] Science if built next to a Campus district. +2 Science at The Enlightenment. Cannot be built next to another Mission.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_MISSION_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>Unlocks the Builder ability to construct a Mission, unique to Spain.[NEWLINE][NEWLINE]+2 [ICON_Faith] Faith. +1 [ICON_Faith] Faith and +1 [ICON_PRODUCTION] Production if built at least 10 tiles away from [ICON_CAPITAL] Capital, otherwise +1 [ICON_HOUSING] Housing.[NEWLINE][NEWLINE]+1 [ICON_Science] Science for every adjacent Campus and Holy Site district. +2 Science at The Enlightenment. Cannot be built next to another Mission.</Text>
+			<Text>Unlocks the Builder ability to construct a Mission, unique to Spain.[NEWLINE][NEWLINE]+2 [ICON_Faith] Faith. +1 [ICON_Faith] Faith and +1 [ICON_PRODUCTION] Production if built at least 8 tiles away from [ICON_CAPITAL] Capital, otherwise +1 [ICON_HOUSING] Housing.[NEWLINE][NEWLINE]+1 [ICON_Science] Science for every adjacent Campus and Holy Site district. +2 Science at The Enlightenment. Cannot be built next to another Mission.</Text>
 		</Replace>
 
 		<!-- == SUMERIA == -->


### PR DESCRIPTION
Gameplay changed tags:
- Spain civ ability and UI - 10 => 8 tiles (I forgot change UI number in previous PR).

Text fixes new tags:
- Babylon leader ability - don't get envoys for non-speciality districts.

English.xml text tested.
- [Database.log](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/files/9542107/Database.log);
- [Localization.log](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/files/9542109/Localization.log);
- [Modding.log](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/files/9542111/Modding.log).

