### PR TITLE
English 5.0.1 fix & pretty icons

### DIFF
--- a/lang/english.xml
+++ b/lang/english.xml
@@ -3,6 +3,10 @@
 	<LocalizedText>
 		<!-- === CIVILIZATIONS === -->
 		<!-- == AMERICA == -->
+		<!-- civilization ability -->
+		<Replace Tag="LOC_TRAIT_CIVILIZATION_FOUNDING_FATHERS_EXPANSION2_DESCRIPTION" Language="en_US">
+			<Text>All Diplomatic policy slots in the current [ICON_Government] government are converted to Wildcard slots. +1 [ICON_FAVOR] Diplomatic Favor per turn for every Wildcard slot in their [ICON_Government] government.</Text>
+		</Replace>
 		<!-- = leader ability (Theodor Roosevelt - base game)= -->
 		<Replace Tag="LOC_TRAIT_LEADER_ROOSEVELT_COROLLARY_DESCRIPTION" Language="en_US">
 			<Text>Units receive a +5 [ICON_Strength] Combat Strength when defending on their home continent or attacking on a foreign continent. +1 Appeal to all tiles in a city with a National Park. Gain the Rough Rider unique unit when they research the Military Science technology.</Text>
@@ -84,7 +88,7 @@
 		<!-- == AZTECS == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_LEGEND_FIVE_SUNS_DESCRIPTION" Language="en_US">
-			<Text>Spend Builder charges to complete 30% of the original district cost. +50% [ICON_PRODUCTION] Production towards land melee units.</Text>
+			<Text>Spend Builder [ICON_Charges] charge to complete 30% of the original district cost. +50% [ICON_PRODUCTION] Production towards land melee units.</Text>
 		</Replace>
 		<!-- = unique building = -->
 		<Replace Tag="LOC_BUILDING_TLACHTLI_DESCRIPTION" Language="en_US">
@@ -97,7 +101,7 @@
 		<!-- == BABYLON == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_BABYLON_DESCRIPTION" Language="en_US">
-			<Text>[ICON_TechBoosted] Eurekas provide 65% of the [ICON_SCIENCE] Science for technologies. Start the game with -50% [ICON_SCIENCE] Science per turn, but each researched technology grants +1% extra [ICON_SCIENCE] Science. Cannot receive additional Eureka bonus from Free Inquiry Golden Age dedication.</Text>
+			<Text>[ICON_TechBoosted] Eurekas provide 65% of the [ICON_SCIENCE] Science for technologies. Start the game with -50% [ICON_SCIENCE] Science per turn, but each researched technology grants +1% extra [ICON_SCIENCE] Science. Cannot receive additional Eureka bonus from Free Inquiry [ICON_GLORY_GOLDEN_AGE] Golden Age dedication.</Text>
 		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_HAMMURABI_DESCRIPTION" Language="en_US">
@@ -161,20 +165,20 @@
 		<!-- == CHINA == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_DYNASTIC_CYCLE_DESCRIPTION" Language="en_US">
-			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspirations provide 60% of civics and technologies instead of 50%. When completing a wonder receive a random [ICON_TechBoosted] Eureka and [ICON_CivicBoosted] Inspiration from the era of the wonder if available.[NEWLINE]Builder receive an additional charge.</Text>
+			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspirations provide 60% of civics and technologies instead of 50%. When completing a wonder receive a random [ICON_TechBoosted] Eureka and [ICON_CivicBoosted] Inspiration from the era of the wonder if available.[NEWLINE]Builder receive an additional [ICON_Charges] charge.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_DYNASTIC_CYCLE_EXPANSION1_DESCRIPTION" Language="en_US">
-			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspirations provide 50% of technologies and civics instead of 40%. When completing a wonder receive a random [ICON_TechBoosted] Eureka and [ICON_CivicBoosted] Inspiration from the era of the wonder if available.[NEWLINE]Builder receive an additional charge.</Text>
+			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspirations provide 50% of technologies and civics instead of 40%. When completing a wonder receive a random [ICON_TechBoosted] Eureka and [ICON_CivicBoosted] Inspiration from the era of the wonder if available.[NEWLINE]Builder receive an additional [ICON_Charges] charge.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_DYNASTIC_CYCLE_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspirations provide 50% of civics and technologies instead of 40%. When completing a wonder receive a random [ICON_TechBoosted] Eureka and [ICON_CivicBoosted] Inspiration from the era of the wonder if available.[NEWLINE]Builder receive an additional charge.</Text>
+			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspirations provide 50% of civics and technologies instead of 40%. When completing a wonder receive a random [ICON_TechBoosted] Eureka and [ICON_CivicBoosted] Inspiration from the era of the wonder if available.[NEWLINE]Builder receive an additional [ICON_Charges] charge.</Text>
 		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_FIRST_EMPEROR_DESCRIPTION" Language="en_US">
-			<Text>When building Ancient and Classical wonders you may spend Builder charges to complete 15% of the original wonder cost.</Text>
+			<Text>When building Ancient and Classical wonders you may spend Builder [ICON_Charges] charge to complete 15% of the original wonder cost.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_LEADER_FIRST_EMPEROR_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>When building Ancient and Classical wonders you may spend Builder charges to complete 15% of the original wonder cost.[NEWLINE]Canals are unlocked with the Masonry technology.</Text>
+			<Text>When building Ancient and Classical wonders you may spend Builder [ICON_Charges] charge to complete 15% of the original wonder cost.[NEWLINE]Canals are unlocked with the Masonry technology.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_CHINESE_CROUCHING_TIGER_DESCRIPTION" Language="en_US">
@@ -282,6 +286,10 @@
 		</Replace>
 
 		<!-- == ENGLAND == -->
+		<!-- = civilization ability = -->
+		<Replace Tag="LOC_TRAIT_CIVILIZATION_INDUSTRIAL_REVOLUTION_DESCRIPTION" Language="en_US"> <!-- charges icon -->
+			<Text>Iron and Coal Mines accumulate 2 more resources per turn. +100% [ICON_PRODUCTION] Production towards Military Engineers. Military Engineers receive +2 [ICON_Charges] charges. Buildings that provide additional yields when [ICON_POWER] Powered receive +4 of that yield. +20% [ICON_PRODUCTION] Production towards Industrial Zone buildings. Harbor buildings increase Strategic Resource Stockpiles by +10 (on Standard Speed).</Text>
+		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_PAX_BRITANNICA_DESCRIPTION" Language="en_US">
 			<Text>All cities founded on a continent other than your home continent receive a free melee unit. Constructing a Royal Navy Dockyard in that city will grant an additional free melee unit. Gain the Redcoat unique unit when the Military Science technology is researched.[NEWLINE]Lighthouse grants +1 [ICON_GREATADMIRAL] Great Admiral point per turn.</Text>
@@ -334,7 +342,7 @@
 		<!-- == FRANCE == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_WONDER_TOURISM_DESCRIPTION" Language="en_US">
-			<Text>Receives a free Spy (and extra spy capacity) with the Castles technology. All spies start as Agents with a free promotion. +20% [ICON_Production] Production toward Medieval, Renaissance, and Industrial era wonders. [ICON_Tourism] Tourism from wonders of any era is +50%.</Text>
+			<Text>Receives a free Spy (and extra spy capacity) with the Castles technology. All spies start as Agents with a [ICON_Promotion] free promotion. +20% [ICON_Production] Production toward Medieval, Renaissance, and Industrial era wonders. [ICON_Tourism] Tourism from wonders of any era is +50%.</Text>
 		</Replace>
 		<!-- = leader ability (Black Queen) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_FLYING_SQUADRON_DESCRIPTION" Language="en_US">
@@ -387,21 +395,25 @@
 		<!-- == GEORGIA == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_GOLDEN_AGE_QUESTS_DESCRIPTION" Language="en_US">
-			<Text>When making Dedications at the beginning of a Golden Age or Heroic Age, receive the Normal Age bonus towards improving Era Score in addition to the other bonus. +50% [ICON_Production] Production towards walls.</Text>
+			<Text>When making Dedications at the beginning of a [ICON_GLORY_GOLDEN_AGE] Golden Age or [ICON_GLORY_SUPER_GOLDEN_AGE] Heroic Age, receive the [ICON_GLORY_NORMAL_AGE] Normal Age bonus towards improving Era Score in addition to the other bonus. +50% [ICON_Production] Production towards walls.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_GOLDEN_AGE_QUESTS_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>When making Dedications at the beginning of a Golden Age or Heroic Age, receive the Normal Age bonus towards improving Era Score in addition to the other bonus. +50% [ICON_Production] Production towards walls.</Text>
+			<Text>When making Dedications at the beginning of a [ICON_GLORY_GOLDEN_AGE] Golden Age or [ICON_GLORY_SUPER_GOLDEN_AGE] Heroic Age, receive the [ICON_GLORY_NORMAL_AGE] Normal Age bonus towards improving Era Score in addition to the other bonus. +50% [ICON_Production] Production towards walls.</Text>
 		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_RELIGION_CITY_STATES_DESCRIPTION" Language="en_US">
 			<Text>Killing a unit provides [ICON_FAITH] Faith equal to 50% of the defeated unit's base [ICON_STRENGTH] Combat Strength (on Online speed). Each [ICON_ENVOY] Envoy you send to a City-state of your majority Religion counts as two [ICON_ENVOY] Envoys (must have a majority Religion). Give +1 [ICON_FAITH] per Envoy in a City-state.</Text>
+		</Replace>
+		<!-- = unique unit = -->
+		<Replace Tag="LOC_ABILITY_GEORGIAN_KHEVSURETI_DESCRIPTION" Language="en_US"> <!-- description fix -->
+			<Text>+7 [ICON_Strength] Combat Strength bonus when fighting in Hill terrain</Text>
 		</Replace>
 		<!-- = unique building = -->
 		<Replace Tag="LOC_BUILDING_TSIKHE_DESCRIPTION" Language="en_US">
 			<Text>A building unique to Georgia which replaces and is stronger than the Ancient Walls. +4 [ICON_Faith] Faith. Provides +1 [ICON_TOURISM] Tourism after advancing to the Conservation Civic.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_TSIKHE_DESCRIPTION_XP2" Language="en_US">
-			<Text>A building unique to Georgia which replaces and is stronger than the Ancient Walls. +4 [ICON_Faith] Faith. Provides +1 [ICON_TOURISM] Tourism after advancing to the Conservation Civic. +100% [ICON_FAITH] Faith and [ICON_TOURISM] Tourism when in a Golden Age.</Text>
+			<Text>A building unique to Georgia which replaces and is stronger than the Ancient Walls. +4 [ICON_Faith] Faith. Provides +1 [ICON_TOURISM] Tourism after advancing to the Conservation Civic. +100% [ICON_FAITH] Faith and [ICON_TOURISM] Tourism when in a [ICON_GLORY_GOLDEN_AGE] Golden or [ICON_GLORY_SUPER_GOLDEN_AGE] Heroic Age.</Text>
 		</Replace>
 
 		<!-- == GERMANY == -->
@@ -409,18 +421,22 @@
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_IMPERIAL_FREE_CITIES_DESCRIPTION" Language="en_US">
 			<Text>After unlocking the Guilds civic, each city can build one more district than usual (exceeding the normal limit based on [ICON_Citizen] Population).</Text>
 		</Replace>
+		<!-- = leader ability = -->
+		<Replace Tag="LOC_TRAIT_LEADER_HOLY_ROMAN_EMPEROR_DESCRIPTION" Language="en_US"> <!-- add icon -->
+			<Text>Additional Military policy slot in any [ICON_Government] government. +7 [ICON_Strength] Combat Strength when attacking city-states.</Text>
+		</Replace>
 
 		<!-- == GREECE == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_PLATOS_REPUBLIC_DESCRIPTION" Language="en_US">
-			<Text>One extra Wildcard policy slot in any government after discovering Political Philosophy civic.</Text>
+			<Text>One extra Wildcard policy slot in any [ICON_Government] government after discovering Political Philosophy civic.</Text>
 		</Replace>
 		<!-- = leader ability (Gorgo) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_THERMOPYLAE_DESCRIPTION" Language="en_US">
-			<Text>Combat victories provide [ICON_Culture] Culture equal to 50% of the [ICON_Strength] Combat Strength of the defeated unit (on Online speed).[NEWLINE][NEWLINE]+1 [ICON_Strength] Combat Strength for each Military policy slot in your government.</Text>
+			<Text>Combat victories provide [ICON_Culture] Culture equal to 50% of the [ICON_Strength] Combat Strength of the defeated unit (on Online speed).[NEWLINE][NEWLINE]+1 [ICON_Strength] Combat Strength for each Military policy slot in your [ICON_Government] government.</Text>
 		</Replace>
 		<Row Tag="LOC_BBG_GORGO_COMBAT_ABILITY_DESCRIPTION" Language="en_US">
-			<Text>[ICON_Strength] Combat Strength +1 for each Military policy slot in your government.</Text>
+			<Text>[ICON_Strength] Combat Strength +1 for each Military policy slot in your [ICON_Government] government.</Text>
 		</Row>
 		<Row Tag="BBG_GORGO_GOVERNMENT_COMBAT_BONUS" Language="en_US">
 			<Text>Military policy slot : +{1_Value}.</Text>
@@ -578,7 +594,7 @@
 		<!-- == KUBLAI (LEADER) == -->
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_KUBLAI_DESCRIPTION" Language="en_US">
-			<Text>One extra Economic policy slot in any government. Receive a random [ICON_TechBoosted] Eureka and [ICON_CivicBoosted] Inspiration when establishing a [ICON_TradingPost] Trading Post in another Civilization's city for the first time.[NEWLINE]+1 [ICON_SCIENCE] science and +1 [ICON_CULTURE] culture per international trade route.</Text>
+			<Text>One extra Economic policy slot in any [ICON_Government] government. Receive a random [ICON_TechBoosted] Eureka and [ICON_CivicBoosted] Inspiration when establishing a [ICON_TradingPost] Trading Post in another Civilization's city for the first time.[NEWLINE]+1 [ICON_SCIENCE] science and +1 [ICON_CULTURE] culture per international trade route.</Text>
 		</Replace>
 		
 
@@ -606,7 +622,7 @@
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_MACEDONIAN_HETAIROI_DESCRIPTION" Language="en_US">
-			<Text>Macedonian unique heavy cavalry unit. Additional +5 [ICON_Strength] Combat Strength when adjacent to a [ICON_GREATGENERAL] Great General from any era. +5 [ICON_GREATGENERAL] Great General points when killing an enemy unit. Starts with 1 free Promotion.</Text>
+			<Text>Macedonian unique heavy cavalry unit. Additional +5 [ICON_Strength] Combat Strength when adjacent to a [ICON_GREATGENERAL] Great General from any era. +5 [ICON_GREATGENERAL] Great General points when killing an enemy unit. Starts with [ICON_Promotion] free Promotion.</Text>
 		</Replace>
 		<!-- = unique building = -->
 		<Replace Tag="LOC_BUILDING_BASILIKOI_PAIDES_DESCRIPTION" Language="en_US">
@@ -641,22 +657,26 @@
 		<Replace Tag="LOC_TRAIT_LEADER_KUPES_VOYAGE_DESCRIPTION" Language="en_US">
 			<Text>Begin the game in an Ocean tile. Gain +1 [ICON_Citizen] Population when settling your first city. The Palace receives +3 [ICON_HOUSING] Housing and +1 [ICON_AMENITIES] Amenity. +2 [ICON_SCIENCE] Science and +2 [ICON_CULTURE] Culture per turn before you settle your first city.</Text>
 		</Replace>
+		<!-- = unique unit = -->
+		<Replace Tag="LOC_UNIT_MAORI_TOA_DESCRIPTION" Language="en_US"> <!-- = charge icon = -->
+			<Text>Māori unique Classical era melee unit. Adjacent enemy units receive -5 [ICON_STRENGTH] Combat Strength. Has 1 [ICON_Charges] charge to build Pā improvement.</Text>
+		</Replace>
 
 		<!-- == MAPUCHE == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_ABILITY_TRAIT_MAPUCHE_DESCRIPTION" Language="en_US">
-			<Text>Unique trait for Mapuche: +5 [ICON_Strength] Combat Strength versus Opponents in Golden Age.</Text>
+			<Text>Unique trait for Mapuche: +5 [ICON_Strength] Combat Strength versus Opponents in [ICON_GLORY_GOLDEN_AGE] Golden Age.</Text>
 		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_LAUTARO_ABILITY_DESCRIPTION_ALT" Language="en_US">
-			<Text>+5 [ICON_Strength] Combat Strength when fighting Free Cities or civilizations that are in a Golden or Heroic Age. Defeating an enemy unit within the borders of an enemy city causes that city to lose 15 Loyalty, doubled if that civilization is in a Golden or Heroic Age.</Text>
+			<Text>+5 [ICON_Strength] Combat Strength when fighting Free Cities or civilizations that are in a [ICON_GLORY_GOLDEN_AGE] Golden or [ICON_GLORY_SUPER_GOLDEN_AGE] Heroic Age. Defeating an enemy unit within the borders of an enemy city causes that city to lose 15 Loyalty, doubled if that civilization is in a [ICON_GLORY_GOLDEN_AGE] Golden or [ICON_GLORY_SUPER_GOLDEN_AGE] Heroic Age.</Text>
 		</Replace>
 		<Row Tag="LOC_PREVIEW_MAPUCHE_COMBAT_BONUS_TOQUI_VS_GOLDEN_AGE_CIV" Language="en_US">
 			<Text>+{1_num} vs. Golden/Heroic Age</Text>
 		</Row>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_MAPUCHE_MALON_RAIDER_DESCRIPTION" Language="en_US">
-			<Text>Mapuche unique Medieval Era unit that replaces the Courser. +1 [ICON_Movement] Movement. Starts with 1 free Promotion.</Text>
+			<Text>Mapuche unique Medieval Era unit that replaces the Courser. +1 [ICON_Movement] Movement. Starts with [ICON_Promotion] free Promotion.</Text>
 		</Replace>
 		<Replace Tag="LOC_ABILITY_MAPUCHE_MALON_RAIDER_DESCRIPTION" Language="en_US">
 			<Text>+1 [ICON_Movement] Movement.</Text>
@@ -714,6 +734,10 @@
 		</Replace>
 
 		<!-- == OTTOMANS == -->
+		<!-- = unique unit = -->
+		<Replace Tag="LOC_UNIT_SULEIMAN_JANISSARY_DESCRIPTION" Language="en_US">
+			<Text>Ottoman unique Renaissance Era unit that replaces the Musketman. Starts with a [ICON_Promotion] free promotion. Stronger and cheaper than the Musketman. To train a Janissary a city must have a population of at least 2. If a city is founded by the Ottomans and trains a Janissary it loses a population.</Text>
+		</Replace>
 		<!-- = unique building = -->
 		<Replace Tag="LOC_BUILDING_GRAND_BAZAAR_DESCRIPTION" Language="en_US">
 			<Text>A building unique to the Ottomans. Accumulate 1 extra Strategic resource for every different type of Strategic resource this city has improved. Receive 1 [ICON_AMENITIES] Amenity for every Luxury resource this city has improved.[NEWLINE]+2 [ICON_GOLD] Gold for each [ICON_TRADEROUTE] trade routes from this city.[NEWLINE]+1 [ICON_GOLD] Gold for each [ICON_TRADEROUTE] trade routes to this city.[NEWLINE]+1 [ICON_TRADEROUTE] Trade route capacity.</Text>
@@ -753,6 +777,10 @@
 		</Replace>
 
 		<!-- == POLAND == -->
+		<!-- = civilization ability = -->
+		<Replace Tag="LOC_TRAIT_CIVILIZATION_GOLDEN_LIBERTY_DESCRIPTION" Language="en_US"> <!-- government icon -->
+			<Text>Culture Bomb adjacent tiles when completing an Encampment or Fort inside friendly territory. One Military policy slot in the current [ICON_Government] government is converted to a Wildcard slot.</Text>	
+		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_LITHUANIAN_UNION_DESCRIPTION" Language="en_US">
 			<Text>The Religion founded by Poland becomes the majority in an adjacent city that loses a tile to a Polish Culture Bomb.[NEWLINE][NEWLINE]Holy Sites gain standard Faith adjacency bonus from adjacent districts.[NEWLINE][NEWLINE]All [ICON_GreatWork_Relic] Relics generate an additional +2 [ICON_Faith] Faith, +2 [ICON_Culture] Culture, and +4 [ICON_Gold] Gold. Recieve a [ICON_GreatWork_Relic] Relic when founding and when completing a Religion.</Text>
@@ -769,7 +797,7 @@
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_PORTUGUESE_NAU_DESCRIPTION" Language="en_US">
-			<Text>Portuguese unique naval melee unit that replaces the Caravel. Starts with 1 free Promotion and is less maintenance. Has 1 charge to build a Feitoria.</Text>
+			<Text>Portuguese unique naval melee unit that replaces the Caravel. Starts with [ICON_Promotion] free Promotion and is less maintenance. Has 1 [ICON_Charges] charge to build a Feitoria.</Text>
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_FEITORIA_DESCRIPTION" Language="en_US">
@@ -781,6 +809,9 @@
 		<Replace Tag="LOC_TRAIT_LEADER_TRAJANS_COLUMN_DESCRIPTION" Language="en_US">
 			<Text>All cities start with an additional City Center building after unlocking Code of Laws. (Starts with a Monument building in the Ancient era).</Text>
 		</Replace>
+		<!-- = unique unit = -->
+		<Replace Tag="LOC_UNIT_ROMAN_LEGION_DESCRIPTION" Language="en_US"> <!-- charge icon -->
+			<Text>Roman unique Classical era melee unit that replaces the Swordsman. Has 1 [ICON_Charges] charge to build a Roman Fort.</Text>		</Replace>
 		<!-- = unique district = -->
 		<Replace Tag="LOC_DISTRICT_BATH_DESCRIPTION" Language="en_US">
 			<Text>A district unique to Rome that replaces the Aqueduct district and is cheaper to build. +1 [ICON_Culture] Culture for every 2 adjacent districts.[NEWLINE][NEWLINE]It provides this city with a source of fresh water from an adjacent River, Lake, Oasis, or Mountain. Cities that do not yet have existing fresh water receive up to 6 [ICON_Housing] Housing. In all cases the Bath provides an additional bonus of +2 [ICON_Housing] Housing and +1 [ICON_Amenities] Amenity. Must be built adjacent to the City Center.</Text>
@@ -806,7 +837,7 @@
 		</Replace>
 		<!-- = unique district = -->
 		<Replace Tag="LOC_DISTRICT_LAVRA_DESCRIPTION" Language="en_US">
-			<Text>A district unique to Russia for religious activity. Replaces the Holy Site district and cheaper to build.[NEWLINE][NEWLINE]Your city border grows by one tile each time a Great Person is used in one of this cities districts. The Lavra provides +1 [ICON_GreatWriter] Great Writer point per turn with a Temple and +1 [ICON_GreatArtist] Great Artist point per turn with a Worship building.</Text>
+			<Text>A district unique to Russia for religious activity. Replaces the Holy Site district and cheaper to build.[NEWLINE][NEWLINE]Your city border grows by one tile each time a [ICON_GreatPerson] Great Person is used in one of this cities districts. The Lavra provides +1 [ICON_GreatWriter] Great Writer point per turn with a Temple and +1 [ICON_GreatArtist] Great Artist point per turn with a Worship building.</Text>
 		</Replace>
 
 		<!-- == SCOTLAND == -->
@@ -842,7 +873,7 @@
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_SPANISH_CONQUISTADOR_DESCRIPTION" Language="en_US">
-			<Text>Spanish unique Renaissance era unit that replaces the Musketman. +5 [ICON_Strength] Combat Strength when there is a religious unit in the same hex. If this unit captures a city or is adjacent to a city when it is captured, the city will automatically adopt the Conquistador player's majority religion.</Text>
+			<Text>Spanish unique Renaissance era unit that replaces the Musketman. +5 [ICON_Strength] Combat Strength when there is a religious unit within 1 hex. If this unit captures a city or is adjacent to a city when it is captured, the city will automatically adopt the Conquistador player's majority religion.</Text>
 		</Replace>
 		<Replace Tag="LOC_ABILITY_CONQUISTADOR_DESCRIPTION" Language="en_US">
 			<Text>+5 [ICON_Strength] Combat Strength when there is a religious unit within one hex.[NEWLINE][ICON_Bullet] If this unit captures a city or is adjacent to a city when it's captured, the city will automatically convert to the Conquistador player's majority Religion.</Text>
@@ -906,7 +937,7 @@
 		<!-- == SWEDEN == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_NOBEL_PRIZE_DESCRIPTION" Language="en_US">
-			<Text>Sweden gains 50 [ICON_Favor] Diplomatic Favor (on Standard speed) when earning a Great Person. Having Sweden in the game adds three unique World Congress competitions starting in the Industrial Era.[NEWLINE][NEWLINE]+1 [ICON_GreatEngineer] Great Engineer point from Factories and +1 [ICON_GreatScientist] Great Scientist point from Universities. +50% [ICON_PRODUCTION] Production towards Libraries, Workshops, Universities, Factories and Government Plaza buildings.</Text>
+			<Text>Sweden gains 50 [ICON_Favor] Diplomatic Favor (on Standard speed) when earning a [ICON_GreatPerson] Great Person. Having Sweden in the game adds three unique World Congress competitions starting in the Industrial Era.[NEWLINE][NEWLINE]+1 [ICON_GreatEngineer] Great Engineer point from Factories and +1 [ICON_GreatScientist] Great Scientist point from Universities. +50% [ICON_PRODUCTION] Production towards Libraries, Workshops, Universities, Factories and Government Plaza buildings.</Text>
 		</Replace>
 		<!-- = unique building = -->
 		<Replace Tag="LOC_BUILDING_QUEENS_BIBLIOTHEQUE_DESCRIPTION" Language="en_US">
@@ -931,13 +962,17 @@
 		</Replace>
 
 		<!-- == ZULU == -->
+		<!-- = civilization ability = -->
+		<Replace Tag="LOC_TRAIT_CIVILIZATION_ZULU_ISIBONGO_DESCRIPTION" Language="en_US"> <!-- icons -->
+			<Text>Cities with a garrisoned unit get +3 Loyalty per turn, or +5 if it is a [ICON_Corps] Corps or [ICON_Army] Army. Conquering a city with a unit will upgrade it into a [ICON_Corps] Corps or [ICON_Army] Army, if the proper Civics are unlocked.</Text>
+		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_AMABUTHO_DESCRIPTION" Language="en_US">
-			<Text>May form Corps (Mercenaries Civic) and Armies (Nationalism Civic) earlier. Gain an additional +3 [ICON_STRENGTH] Base Combat Strength to both Corps and Armies at the Nationalism Civic, up to +5 [ICON_STRENGTH] Base Combat Strength at the Mobilization Civic.</Text>
+			<Text>May form [ICON_Corps] Corps at the Mercenaries Civic and [ICON_Army] Armies at the Nationalism Civic, both gain +3 [ICON_STRENGTH] base Combat Strength at the Nationalism Civic and up to +5 [ICON_STRENGTH] base Combat Strength at the Mobilization Civic.</Text>
 		</Replace>
 		<!-- = unique district = -->
 		<Replace Tag="LOC_DISTRICT_IKANDA_DESCRIPTION" Language="en_US">
-			<Text>A district unique to Zulu which replaces the Encampment. Provides +1 [ICON_Housing] Housing. Once the Civic or Technology prerequisite is met, Corps and Armies can be built outright. Buildings in the Ikanda receive +2 [ICON_GOLD] Gold and +1 [ICON_CULTURE] Culture. Faster Corps and Army creation.</Text>
+			<Text>A district unique to Zulu which replaces the Encampment. Provides +1 [ICON_Housing] Housing. Buildings in the Ikanda receive +2 [ICON_GOLD] Gold and +1 [ICON_CULTURE] Culture.[NEWLINE]Once required Civics are unlocked, allows [ICON_Corps] Corps or [ICON_Army] Armies to be trained directly and their costs reduced by 25%.</Text>
 		</Replace>
 		
 		
@@ -958,6 +993,9 @@
 		</Row>
 		<Replace Tag="LOC_UNIT_LAHORE_NIHANG_DESCRIPTION" Language="en_US">
 			<Text>Lahore City-State unique unit with a unique Promotion tree. Purchasable with [ICON_Faith] Faith. +15 [ICON_Strength] Combat Strength when Barracks, Armory, and Military Academy buildings are first constructed. Receives bonuses from [ICON_GREATGENERAL] Great General from any era.</Text>
+		</Replace>
+		<Replace Tag="LOC_UNIT_TRADER_DESCRIPTION" Language="en_US"> <!-- embarkation tip -->
+			<Text>May make and maintain a single [ICON_TradeRoute] Trade Route. Automatically creates Roads as it travels. Can embark since Celestial Navigation technology is researched.</Text>
 		</Replace>
 
 
@@ -1002,6 +1040,12 @@
 		<Replace Tag="LOC_PROMOTION_MONK_COBRA_STRIKE_DESCRIPTION" Language="en_US">
 			<Text>+7 [ICON_Strength] Combat Strength in all situations.</Text>
 		</Replace>
+		<Replace Tag="LOC_PROMOTION_BOARDING_DESCRIPTION" Language="en_US">
+			<Text>Obtain [ICON_Gold] Gold equal to 50% of the [ICON_Strength] Combat Strength of the defeated naval unit (on Online speed).</Text>
+		</Replace>
+		<Replace Tag="LOC_PROMOTION_ARROW_STORM_DESCRIPTION" Language="en_US">
+			<Text>+7 [ICON_Ranged] Ranged Strength when attacking.</Text>
+		</Replace>
 
 
 
@@ -1012,6 +1056,9 @@
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_RESOURCE_MANAGER_BLACK_MARKETEER_DESCRIPTION" Language="en_US">
 			<Text>Strategic resources are not required in the city in order to build resource dependent units.</Text>
+		</Replace>
+		<Replace Tag="LOC_GOVERNOR_PROMOTION_EMBRASURE_DESCRIPTION" Language="en_US">
+			<Text>City gains an additional [ICON_Ranged] Ranged Strike per turn. Military units trained in this city start with a [ICON_Promotion] free promotion that do not already start with a [ICON_Promotion] free promotion.</Text>
 		</Replace>
 
 		<!-- == Reyna == -->
@@ -1062,7 +1109,7 @@
 			<Text>Allows city to purchase districts with [ICON_FAITH] Faith.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_CARDINAL_PATRON_SAINT_DESCRIPTION" Language="en_US">
-			<Text>Apostles and Warrior Monks trained in this city receive second free promotion immediately after earning their first promotion through normal means.</Text>
+			<Text>Apostles and Warrior Monks trained in this city receive second [ICON_Promotion] free promotion immediately after earning their first [ICON_Promotion] promotion through normal means.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_THE_CARDINAL_DESCRIPTION" Language="en_US">
 			<Text>{LOC_GOVERNOR_THE_CARDINAL_NAME} is a Spiritual and Religious leader that can increase the [ICON_CULTURE] Cultural Significance and [ICON_Religion] Religious Fortitude of a city.</Text>
@@ -1147,7 +1194,7 @@
 			<Text>+1 [ICON_Production] Production and +1 [ICON_Faith] Faith from Quarries.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_CITY_PATRON_GODDESS_DESCRIPTION" Language="en_US">
-			<Text>+50% [ICON_Production] Production toward districts in cities without a specialty district.</Text>
+			<Text>+50% [ICON_Production] Production toward all districts in cities without a specialty district.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_DANCE_OF_THE_AURORA_DESCRIPTION" Language="en_US">
 			<Text>Holy Site districts get +1 [ICON_Faith] Faith from adjacent flat Tundra tiles.</Text>
@@ -1159,10 +1206,10 @@
 			<Text>+3 [ICON_FAITH] Faith from Geothermal Fissures and Volcanic Soil.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_INITIATION_RITES_DESCRIPTION" Language="en_US">
-			<Text>When chosen receive a Warrior in your [ICON_Capital] Capital. Receive 35% of a non-military land unit's production value in [ICON_FAITH] Faith when produced.</Text>
+			<Text>When chosen receive a Warrior in your [ICON_Capital] Capital. Receive 35% of a non-civilian land unit's production value in [ICON_FAITH] Faith when produced.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_INITIATION_RITES_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>When chosen receive a Warrior in your [ICON_Capital] Capital. Receive 35% of a non-military land unit's production value in [ICON_FAITH] Faith when produced.</Text>
+			<Text>When chosen receive a Warrior in your [ICON_Capital] Capital. Receive 35% of a non-civilian land unit's production value in [ICON_FAITH] Faith when produced.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_LADY_OF_THE_REEDS_AND_MARSHES_EXPANSION2_DESCRIPTION" Language="en_US">
 			<Text>+1 [ICON_Production] Production from Marsh, Oasis, and Floodplains.</Text>
@@ -1278,7 +1325,7 @@
 			<Text>Unlocks the Builder ability to construct Plantations.[NEWLINE][NEWLINE]+2 [ICON_Gold] Gold. +1 [ICON_PRODUCTION] Production if built on flat tile.[NEWLINE]Can only be built on valid resources.[NEWLINE][NEWLINE]If built on Luxury resources, the city will gain use of that resource.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_GEOTHERMAL_PLANT_DESCRIPTION" Language="en_US">
-			<Text>Unlocks the Builder ability to construct a Geothermal Plant.[NEWLINE][NEWLINE]+1 [ICON_Science] Science. +2 [ICON_Production] Production. Provides 3 [ICON_Power] Power per turn.[NEWLINE]+1 [ICON_Science] Science and +3 [ICON_Power] Power per turn one Synthetic materials researched.[NEWLINE]Must be built on a Geothermal Fissure.</Text>
+			<Text>Unlocks the Builder ability to construct a Geothermal Plant.[NEWLINE][NEWLINE]+2 [ICON_Production] Production, +1 [ICON_Science] Science, +3 [ICON_Power] Power per turn.[NEWLINE]Additional +1 [ICON_Production] Production, +1 [ICON_Science] Science and +3 [ICON_Power] Power per turn one Synthetic materials researched.[NEWLINE]Must be built on a Geothermal Fissure.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_FISHING_BOATS_DESCRIPTION" Language="en_US">
 			<Text>Unlocks the Builder ability to construct Fishing Boats.[NEWLINE][NEWLINE]+1 [ICON_Food] Food and +1 [ICON_PRODUCTION] Production. Can only be built on valid resources.[NEWLINE][NEWLINE]If built on Luxury resources, the city will gain use of that resource.</Text>
@@ -1291,10 +1338,28 @@
 
 		<!-- === BUILDINGS === -->
 		<Replace Tag="LOC_BUILDING_CHANCERY_DESCRIPTION" Language="en_US">
-			<Text>+3 Influence Points per turn. When this civilization captures or kills an enemy Spy, receive 200 [ICON_Science] Science (on Standard speed) for every level of the enemy Spy.</Text>
+			<Text>+3 [ICON_InfluencePerTurn] Influence Points per turn. When this civilization captures or kills an enemy Spy, receive 200 [ICON_Science] Science (on Standard speed) for every level of the enemy Spy.</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_CONSULATE_DESCRIPTION" Language="en_US">
+			<Text>+2 [ICON_InfluencePerTurn] Influence Points per turn. Enemy Spy's level is reduced by 1 when targeting this city or cities with Encampments.</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_GOV_CITYSTATES_DESCRIPTION" Language="en_US">
+			<Text>Leveraging City-states costs half [ICON_Gold] Gold. City-state units gain +4 [ICON_Strength] Combat Strength if you are the City-state's Suzerain (including Leveraged Units).[NEWLINE]Awards +1 [Icon_Governor] Governor Title, +2 [ICON_Envoy] Envoys and +2 [ICON_InfluencePerTurn] Influence Points per turn.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_GOV_CITYSTATES_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>+3 [ICON_Favor] Diplomatic Favor. Leveraging City-states costs half [ICON_Gold] Gold.[NEWLINE]City-state units gain +4 [ICON_Strength] Combat Strength if you are the City-state's Suzerain (including Leveraged Units).[NEWLINE]Awards +1 [Icon_Governor] Governor Title. +2 envoys and +2 influence per turn towards envoys.</Text>
+			<Text>+3 [ICON_Favor] Diplomatic Favor. Leveraging City-states costs half [ICON_Gold] Gold. City-state units gain +4 [ICON_Strength] Combat Strength if you are the City-state's Suzerain (including Leveraged Units).[NEWLINE]Awards +1 [Icon_Governor] Governor Title, +2 [ICON_Envoy] Envoys and +2 [ICON_InfluencePerTurn] Influence Points per turn.</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_GOV_TALL_DESCRIPTION" Language="en_US">
+			<Text>+1 [ICON_Amenities] Amenity, +2 [ICON_FOOD] Food, and +3 [ICON_Housing] Housing in Cities with [ICON_Governor] Governors[NEWLINE]-2 Loyalty in Cities without [ICON_Governor] Governors.[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_GOV_CONQUEST_DESCRIPTION" Language="en_US">
+			<Text>+25% [ICON_Production] Production towards all naval and land military units. Reduces the maintenance cost of units by 1 [ICON_GOLD] Gold.[NEWLINE]Awards +1 [Icon_Governor] Governor Title and increases Strategic Resources stockpiles by 15.</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_GOV_FAITH_DESCRIPTION" Language="en_US">
+			<Text>Grants the ability to buy land units with [ICON_Faith] Faith in all owned cities.[NEWLINE]Pillaging Improvements and Districts provides bonus [ICON_Faith] Faith.[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_GOV_SCIENCE_DESCRIPTION" Language="en_US">
+			<Text>Builders and Military Engineers gain the ability to use all of their [ICON_Charges] charges to provide bonus [ICON_Production] Production to a District Project. Each [ICON_Charges] charge grants 2% of project [ICON_Production] Production. Once per city per turn.[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_SEAPORT_DESCRIPTION" Language="en_US">
 			<Text>+25% combat experience for all naval units trained in this city. Allows Fleets and Armadas to be trained directly. Fleet and Armada training costs reduced 25%. +2 [ICON_GOLD] Gold on all Coast tiles for this city.</Text>
@@ -1312,22 +1377,7 @@
 			<Text>+50% combat experience for air units trained in this city. +2 air unit slots in Aerodrome district. Allows the ability to airlift land units between Aerodrome districts with Airports after the Rapid Deployment civic is unlocked. +2 [ICON_RESOURCE_ALUMINUM] Aluminum per turn once discovered.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_MILITARY_ACADEMY_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>+25% combat experience for all land units trained in this city.[NEWLINE]Strategic Resource Stockpiles increased +10 (on Standard speed).[NEWLINE]Allows Corps and Armies to be trained directly. Corps and Army training costs reduced 25%. +2 [ICON_RESOURCE_OIL] Oil per turn once discovered.</Text>
-		</Replace>
-		<Replace Tag="LOC_BUILDING_GOV_TALL_DESCRIPTION" Language="en_US">
-			<Text>+1 [ICON_Amenities] Amenity, +2 [ICON_FOOD] Food, and +3 [ICON_Housing] Housing in Cities with [ICON_Governor] Governors[NEWLINE]-2 Loyalty in Cities without [ICON_Governor] Governors.[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
-		</Replace>
-		<Replace Tag="LOC_BUILDING_GOV_CONQUEST_DESCRIPTION" Language="en_US">
-			<Text>+25% [ICON_Production] Production towards all naval and land military units. Reduces the maintenance cost of units by 1 [ICON_GOLD] Gold.[NEWLINE]Awards +1 [Icon_Governor] Governor Title and increases Strategic Resources stockpiles by 15.</Text>
-		</Replace>
-		<Replace Tag="LOC_BUILDING_GOV_FAITH_DESCRIPTION" Language="en_US">
-			<Text>Grants the ability to buy land units with [ICON_Faith] Faith in all owned cities.[NEWLINE]Pillaging Improvements and Districts provides bonus [ICON_Faith] Faith.[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
-		</Replace>
-		<Replace Tag="LOC_BUILDING_GOV_CITYSTATES_DESCRIPTION" Language="en_US">
-			<Text>Leveraging City-states costs half [ICON_Gold] Gold.[NEWLINE]City-state units gain +4 [ICON_Strength] Combat Strength if you are the City-state's Suzerain (including Leveraged Units).[NEWLINE]Awards +1 [Icon_Governor] Governor Title. +2 envoys and +2 influence per turn towards envoys.</Text>
-		</Replace>
-		<Replace Tag="LOC_BUILDING_GOV_SCIENCE_DESCRIPTION" Language="en_US">
-			<Text>Builders and Military Engineers gain the ability to use all of their charges to provide bonus [ICON_Production] Production to a District Project. Each charge grants 2% of project [ICON_Production] Production. Once per city per turn.[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
+			<Text>+25% combat experience for all land units trained in this city.[NEWLINE]Strategic Resource Stockpiles increased +10 (on Standard speed). +2 [ICON_RESOURCE_OIL] Oil per turn once discovered.[NEWLINE]Once required Civics are unlocked, allows [ICON_Corps] Corps or [ICON_Army] Armies to be trained directly and their costs reduced by 25%.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_WATER_MILL_DESCRIPTION" Language="en_US">
 			<Text>Farms gain +1 [ICON_PRODUCTION] Production. City must be adjacent to a River.</Text>
@@ -1410,13 +1460,13 @@
 
 		<!-- === WORLD WONDERS === -->
 		<Replace Tag="LOC_BUILDING_ST_BASILS_CATHEDRAL_DESCRIPTION" Language="en_US">
-			<Text>Awards 1 [ICON_GreatWork_Relic] Relic and 3 [ICON_GreatWork_Relic] Relic slots. +100% [ICON_Tourism] Religious Tourism from this city. +1 [ICON_Food] Food, +1 [ICON_Production] Production, and +1 [ICON_Culture] Culture on all Tundra tiles for this city. Must be built adjacent to a City Center.</Text>
+			<Text>Awards 1 [ICON_GreatWork_Relic] Relic and 3 [ICON_GreatWork_Relic] Relic slots. +100% [ICON_Tourism] Religious Tourism from this city. +1 [ICON_Food] Food, +1 [ICON_Production] Production, and +1 [ICON_Culture] Culture on all Tundra tiles for this city.[NEWLINE][NEWLINE]Must be built adjacent to a City Center.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_CRISTO_REDENTOR_DESCRIPTION" Language="en_US">
-			<Text>Awards 1 Relic [ICON_GreatWork_Relic]. Holy City and [ICON_GreatWork_Relic] Relic [ICON_Tourism] Tourism is not diminished by other civilizations who have researched The Enlightenment civic. +100% [ICON_Tourism] Tourism from Seaside Resorts across your civilization. Must be built on Hills.</Text>
+			<Text>Awards 1 Relic [ICON_GreatWork_Relic]. Holy City and [ICON_GreatWork_Relic] Relic [ICON_Tourism] Tourism is not diminished by other civilizations who have researched The Enlightenment civic. +100% [ICON_Tourism] Tourism from Seaside Resorts across your civilization.[NEWLINE][NEWLINE]Must be built on Hills.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_AMUNDSEN_SCOTT_RESEARCH_STATION_DESCRIPTION" Language="en_US">
-			<Text>+20% [ICON_SCIENCE] Science and 10% [ICON_PRODUCTION] Production in all cities. If there are 5 Tundra or Tundra Hills tiles within 3 tiles of a city and owned by this player these yields are doubled. Must be built next to a Campus with a Research Lab on a Tundra or Snow tile.</Text>
+			<Text>+20% [ICON_SCIENCE] Science and 10% [ICON_PRODUCTION] Production in all cities. If there are 5 Tundra or Tundra Hills tiles within 3 tiles of a city and owned by this player these yields are doubled.[NEWLINE][NEWLINE]Must be built next to a Campus with a Research Lab on a Tundra or Snow tile.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_JEBEL_BARKAL_EXPANSION2_DESCRIPTION" Language="en_US">
 			<Text>Awards 4 [ICON_RESOURCE_IRON] Iron per turn. +4 [ICON_Faith] Faith to each your City Center within 6 tiles.[NEWLINE][NEWLINE]Must be built on Desert Hills.</Text>
@@ -1425,23 +1475,30 @@
 			<Text>+1 [ICON_ENVOY] Envoy when you build a wonder, including Apadana, in this city.[NEWLINE][NEWLINE]Must be built adjacent to your [ICON_CAPITAL] Capital.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_VENETIAN_ARSENAL_DESCRIPTION" Language="en_US">
-			<Text>+75% [ICON_Production] Production towards naval units in all cities. Must be built on a Coast tile that is adjacent to an Industrial Zone district.</Text>
+			<Text>+75% [ICON_Production] Production towards naval units in all cities.[NEWLINE][NEWLINE]Must be built on a Coast tile that is adjacent to an Industrial Zone district.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_HANGING_GARDENS_DESCRIPTION" Language="en_US">
-			<Text>Increases growth by 15% in all cities. +2 [ICON_HOUSING] Housing in the city in which this wonder is built and +1 [ICON_HOUSING] Housing in all other cities within 6 tiles. Must be built next to a river.</Text>
+			<Text>Increases growth by 15% in all cities. +2 [ICON_HOUSING] Housing in the city in which this wonder is built and +1 [ICON_HOUSING] Housing in all other cities within 6 tiles.[NEWLINE][NEWLINE]Must be built next to a river.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_COLOSSEUM_DESCRIPTION" Language="en_US">
-			<Text>+1 [ICON_Culture] Culture, +2 Loyalty, +2 [ICON_Amenities] Amenities to each your City Center within 6 tiles. Must be built on flat land adjacent to an Entertainment Complex with an Arena.</Text>
+			<Text>+1 [ICON_Culture] Culture, +2 Loyalty, +2 [ICON_Amenities] Amenities to each your City Center within 6 tiles.[NEWLINE][NEWLINE]Must be built on flat land adjacent to an Entertainment Complex with an Arena.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_ETEMENANKI_DESCRIPTION" Language="en_US">
 			<Text>+1 [ICON_SCIENCE] Science and +1 [ICON_PRODUCTION] Production to all Marsh tiles in your empire and on all Floodplains tiles for this city.[NEWLINE][NEWLINE]Must be built on Floodplains or Marsh.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_HUEY_TEOCALLI_DESCRIPTION" Language="en_US">
-			<Text>+1 [ICON_Amenities] Amenity from entertainment for each Lake tile within one tile of Huey Teocalli. +1 [ICON_Food] Food, +1 [ICON_Production] Production, +2 [ICON_CULTURE] Culture for each Lake tile in your empire. Must be built on a Lake tile adjacent to land.</Text>
+			<Text>+1 [ICON_Amenities] Amenity from entertainment for each Lake tile within one tile of Huey Teocalli. +1 [ICON_Food] Food, +1 [ICON_Production] Production, +2 [ICON_CULTURE] Culture for each Lake tile in your empire.[NEWLINE][NEWLINE]Must be built on a Lake tile adjacent to land.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_STATUE_LIBERTY_EXPANSION2_DESCRIPTION" Language="en_US">
 			<Text>+3 Diplomatic Victory Points when built. All your cities within 6 tiles are always 100% Loyal.[NEWLINE][NEWLINE]Must be built on the Coast, adjacent to land and a Harbor district.</Text>
 		</Replace>
+		<Replace Tag="LOC_BUILDING_TERRACOTTA_ARMY_DESCRIPTION" Language="en_US">
+			<Text>All current units gain a [ICON_Promotion] promotion level. All Archaeologists from the owner may enter foreign lands without Open Borders.[NEWLINE][NEWLINE]Must be built on flat Grassland or Plains adjacent to an Encampment district with a Barracks or Stable.</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_PYRAMIDS_DESCRIPTION" Language="en_US">
+			<Text>Grants a free Builder and +1 [ICON_Charges] charge for all existing and new Builders.[NEWLINE][NEWLINE]Must be built on flat Desert tile (including Floodplains).</Text>
+		</Replace>
+		
 
 
 
@@ -1501,6 +1558,24 @@
 		<Replace Tag="LOC_LEADER_TRAIT_LAHORE_DESCRIPTION" Language="en_US">
 			<Text>Your cities can now train Nihang units.[NEWLINE][NEWLINE]A unit with a unique Promotion tree. Purchasable with [ICON_Faith] Faith. +15 [ICON_Strength] Combat Strength when Barracks, Armory, and Military Academy buildings are first constructed. Receives bonuses from [ICON_GREATGENERAL] Great General from any era.</Text>
 		</Replace>
+		<Replace Tag="LOC_CIVILIZATION_ARMAGH_BONUS" Language="en_US">
+			<Text>Your Builders can now make Monastery improvements.[NEWLINE][NEWLINE]Monasteries provide +3 [ICON_Faith] Faith. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_ARMAGH_DESCRIPTION" Language="en_US">
+			<Text>Your Builders can now make Monastery improvements.[NEWLINE][NEWLINE]Monasteries provide +3 [ICON_Faith] Faith. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
+		</Replace>
+		<Replace Tag="LOC_CIVILIZATION_ARMAGH_BONUS_XP2" Language="en_US">
+			<Text>Your Builders can now make Monastery improvements.[NEWLINE][NEWLINE]Monasteries provide +3 [ICON_Faith] Faith. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_ARMAGH_EXPANSION2_DESCRIPTION" Language="en_US">
+			<Text>Your Builders can now make Monastery improvements.[NEWLINE][NEWLINE]Monasteries provide +3 [ICON_Faith] Faith. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
+		</Replace>
+		<Replace Tag="LOC_IMPROVEMENT_MONASTERY_DESCRIPTION" Language="en_US">
+			<Text>Unlocks the Builder ability to construct a Monastery.[NEWLINE][NEWLINE]+3 [ICON_Faith] Faith. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
+		</Replace>
+		<Replace Tag="LOC_IMPROVEMENT_MONASTERY_EXPANSION2_DESCRIPTION" Language="en_US">
+			<Text>Unlocks the Builder ability to construct a Monastery.[NEWLINE][NEWLINE]+3 [ICON_Faith] Faith. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
+		</Replace>
 
 
 
@@ -1509,7 +1584,7 @@
 			<Text>To Arms! Golden Age:[NEWLINE]Unlock a special Casus Belli which gives 75% less warmonger penalties than Formal War and can be used immediately after Denouncing the target. +15% [ICON_Production] Production towards military units. All military units gain +10 [ICON_Strength] against cities.</Text>
 		</Replace>
 		<Replace Tag="LOC_PEDIA_CONCEPTS_PAGE_DEDICATIONS_CHAPTER_CONTENT_PARA_9" Language="en_US">
-			<Text>To Arms!: Gain +1 Era Score each time you kill a non-barbarian Corps in combat and +2 Era Score each time you kill a non-barbarian Army in combat. If chosen at the start of a Golden Age, unlocks a special Casus Belli which gives 75% less warmonger penalties than formal war and can be used immediately after Denouncing the target. +15% [ICON_Production] Production towards military units and military units gain +10 [ICON_Strength] against cities. Industrial through Atomic Era.</Text>
+			<Text>To Arms!: Gain +1 Era Score each time you kill a non-barbarian [ICON_Corps] Corps in combat and +2 Era Score each time you kill a non-barbarian [ICON_Army] Army in combat. If chosen at the start of a Golden Age, unlocks a special Casus Belli which gives 75% less warmonger penalties than formal war and can be used immediately after Denouncing the target. +15% [ICON_Production] Production towards military units and military units gain +10 [ICON_Strength] against cities. Industrial through Atomic Era.</Text>
 		</Replace>
 		<Row Tag="LOC_MILITARY_GA_BUFF_DESCRIPTION" Language="en_US">
 			<Text>+10 [ICON_STRENGTH] against defensible districts (To Arms! Golden Age dedication).</Text>
@@ -1632,7 +1707,7 @@
 			<Text>+50% [ICON_Production] Production toward walls.</Text>
 		</Replace>
 		<Replace Tag="LOC_POLICY_BASTIONS_DESCRIPTION" Language="en_US">
-			<Text>+6 City [ICON_Strength] Defense Strength. +6 City [ICON_Ranged] Ranged Strength.</Text>
+			<Text>+6 City [ICON_Strength] Defense Strength and +6 City [ICON_Ranged] Ranged Strength for walled districts.</Text>
 		</Replace>
 		<Replace Tag="LOC_POLICY_PRAETORIUM_DESCRIPTION" Language="en_US">
 			<Text>[ICON_Governor] Governors provide +4 Loyalty per turn to their city.</Text>
@@ -1649,12 +1724,43 @@
 		<Replace Tag="LOC_GOVT_INHERENT_BONUS_MONARCHY_XP1" Language="en_US">
 			<Text>[ICON_HOUSING] Housing per level of Walls. +2 [ICON_CULTURE] Culture for every Renaissance Walls.</Text>
 		</Replace>
+		<Replace Tag="LOC_POLICY_CHARISMATIC_LEADER_DESCRIPTION" Language="en_US">
+			<Text>+2 [ICON_InfluencePerTurn] Influence Points per turn.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_GUNBOAT_DIPLOMACY_DESCRIPTION" Language="en_US">
+			<Text>Open Borders with all city-states, and +4 [ICON_InfluencePerTurn] Influence Points per turn.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_NUCLEAR_ESPIONAGE_DESCRIPTION" Language="en_US">
+			<Text>Spies who steal a [ICON_TechBoosted] tech boost without being detected gain an extra [ICON_TechBoosted] boost.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_INSULAE_DESCRIPTION" Language="en_US">
+			<Text>+1 [ICON_Housing] Housing in all cities with at least 1 specialty district.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_ROGUE_STATE_DESCRIPTION" Language="en_US">
+			<Text>+50% [ICON_Production] Production to nuclear program projects and Nuclear Devices.[NEWLINE]BUT: Earn no [ICON_InfluencePerTurn] Influence Points per turn.</Text>
+		</Replace>
+
+		<Replace Tag="LOC_GOVT_ACCUMULATED_BONUS_BRIEF_AUTOCRACY_XP1" Language="en_US">
+			<Text>+10% [ICON_Production] Production toward Wonders.</Text>
+		</Replace>
+		<Replace Tag="LOC_GOVT_ACCUMULATED_BONUS_BRIEF_CLASSREP_XP1" Language="en_US">
+			<Text>+15% [ICON_GreatPerson] Great Person points.</Text>
+		</Replace>
+		<Replace Tag="LOC_GOVT_ACCUMULATED_BONUS_BRIEF_MERCHREP_XP1" Language="en_US">
+			<Text>+15% [ICON_Production] Production toward Districts.</Text>
+		</Replace>
+		<Replace Tag="LOC_GOVT_ACCUMULATED_BONUS_BRIEF_MONARCHY_XP1" Language="en_US">
+			<Text>+50% [ICON_InfluencePerTurn] Influence Points.</Text>
+		</Replace>
+		<Replace Tag="LOC_GOVT_ACCUMULATED_BONUS_BRIEF_FASCISM_XP1" Language="en_US">
+			<Text>+50% [ICON_Production] Production toward Units.</Text>
+		</Replace>
 
 
 
 		<!-- === GREAT PEOPLE === -->
 		<Replace Tag="LOC_GREATPERSON_BOUDICA_ACTIVE" Language="en_US">
-			<Text>Creates Military Engineer in your [ICON_Capital] Capital.</Text>
+			<Text>Creates a Military Engineer in your [ICON_Capital] Capital.</Text>
 		</Replace>
 		<Replace Tag="LOC_GREATPERSON_AETHELFLAED_ACTIVE" Language="en_US">
 			<Text>Instantly creates a Trebuchet unit with one promotion level.</Text>
@@ -1694,6 +1800,9 @@
 		<Replace Tag="LOC_GREATPERSON_CITY_APPEAL_SMALL" Language="en_US">
 			<Text>This city provides +{Amount} Appeal to any tiles it owns. This city receives +2 [ICON_Gold] Gold from each breathtaking tile.</Text>
 		</Replace>
+		<Replace Tag="LOC_GREATPERSON_WONDER_PURCHASE" Language="en_US">
+			<Text>Purchase [ICON_Production] Production towards wonder construction at the rate of 2 [ICON_GOLD] Gold per 1 [ICON_Production] Production.</Text>
+		</Replace>
 		<!-- Jamsetji Tata, Masaru Ibuka, Raja Todar Mal, John Spilsbury - no text fixes -->
 		<Replace Tag="LOC_GREATPERSON_CITY_STATE_ABSORB_EXPANSIONS" Language="en_US">
 			<Text>Absorbs this City-state into your empire. Grants you +10 Loyalty per turn in the city. Can be an enemy City-state.</Text>
@@ -1703,10 +1812,10 @@
 		</Replace>
 
 		<Replace Tag="LOC_GREATPERSON_DMITRI_MENDELEEV_ACTIVE" Language="en_US">
-			<Text>Triggers the [ICON_TechBoosted] Eureka for Chemistry and 1 random technology from the Industrial era. +50% [ICON_Production] Production towards Research Lab building.</Text>
+			<Text>Triggers the [ICON_TechBoosted] Eureka for Chemistry and 1 random technology from the Industrial era. +50% [ICON_Production] Production towards Research Lab buildings.</Text>
 		</Replace>
 		<Replace Tag="LOC_GREAT_PERSON_GRANT_LOTSO_SCIENCE" Language="en_US">
-			<Text>Grants 2000 [ICON_SCIENCE] Science and [ICON_CULTURE] Culture (on Standard speed). Can only be activated on another civilization or City-state's Campus.</Text>
+			<Text>Grants 2000 [ICON_SCIENCE] Science and [ICON_CULTURE] Culture (on Standard speed). Must be activated on non-hostile foreign civilization or City-state's Campus.</Text>
 		</Replace>
 		<Replace Tag="LOC_GREATPERSON_GREAT_PERSON_FREE_POINTS" Language="en_US">
 			<Text>Applies {Amount} free [ICON_GreatPerson] Great People points towards recruiting all current and future Great People. Grants 1 Diplomatic Victory Point.</Text>


### PR DESCRIPTION
This pull-request contain lot of minor text fixes. Most of them just add icon to description.
Please look carefully!

New lines:

- America civ ability (icon) - government icon;
- England civ ability (icon) - charge icon;
- Georgia UU - fix ability description (in combat);
- Germany civ ability (icon) - government icon;
- Maori UU (icon) - charge icon;
- Ottoman UU (icon) - promotion icon;
- Poland civ ability (icon) - government icon;
- Rome UU (icon) - charge icon;
- Zulu civ ability (icon) - corps and army icons;
> 
- Trader - embarkation tip;
- Naval Raider R1 promotion - 50% combat strength to gold tip;
- Ranged L2 promotion - vs. districts too;
>
- Consulate building (icon) - influence icon;
>
- Victor L2 promotion (icon) - promotion icon;
>
- Terracotta Army (icon) - promotion icon, additional newlines between description and requirements;
- Pyramids (icon) - charge icon, additional newlines between description and requirements;
>
- Armagh City-state - Monastery +3 faith (not +2);
- Monastery improvement - +3 faith (not +2);
>
- Charismatic leader policy (icon) - influence icon, shorter description;
- Gunboat diplomacy policy (icon) - influence icon, shorter description;
- Nuclear espionage policy (icon) - eureka icons;
- Insulae policy - +1 housing for 1 districts, not 2 (tested);
- Rogue state policy (icon) - influence icon, shorter description;
>
- Autocracy government bonus (icon) - production icon;
- Classical Republic bonus (icon) - great person icon;
- Merchant Republic bonus (icon) - production icon;
- Monarchy bonus (icon) - influence icon;
- Fascism bonus (icon) - production icon;
>
- Shah Jahān Engineer - rework description to more clear.

Changed lines:

- Aztec civ ability (icon) - charge icon;
- Babylon civ ability (icon) - golden age icon;
- China civ ability - charge icon;
- China leader ability (Qin) (icon) - charge icon;
- France leader ability (BQ) (icon) - promotion icon;
- Georgia civ ability (icon) - normal, golden, heroic icons;
- Georgia UB (icon) - golden, heroic icons;
- Greece civ ability (icon) - government icon;
- Greece leader ability (Gorgo) (icon) - government icon;
- Kublai (leader) ability (icon) - government icon;
- Macedon UU (icon) - promotion icon;
- Mapuche leader ability (icon) - golden age icon;
- Mapuche UU (icon) - promotion icon;
- Portugal UU (icon) - charge icon;
- Russia UD (icon) - great person icon;
- Spain UU - additional combat strength if religious unit within 1 hex (not the same tile);
- Sweden civ ability - great person icon;
- Zulu civ leader ability (icon) - corps and army icons;
- Zulu UD (icon) - corps and army icons;
>
- Moksha R2 promotion (icon) - promotion icons;
>
- City Patron Goddess pantheon - for "all" districts tip;
- Initiation Rites pantheon - **fix "non-civilian" (not non-military);**
>
- Geothermal Plant - fix description;
- Chancery building (icon) - influence icon;
- Foreign ministry building (icon) - influence icon;
- Royal Society building (icon) - charge icon;
>
- St. Basils Cathedral - additional newlines between description and requirements;
- Cristo Redentor - additional newlines between description and requirements;
- Amundsen Scott research station - additional newlines between description and requirements;
- Venetian Arsenal - additional newlines between description and requirements;
- Hanging Gardens - additional newlines between description and requirements;
- Colosseum - additional newlines between description and requirements;
- Huey Teocalli - additional newlines between description and requirements;
>
- To Arms! dedication (icon) - corps and army icons;
>
- Bastions policy - tip, work for walled districts only;
>
- Boudica (English fix) - "a";
- Dmitri Mendeleev (English fix) - "buildingS";
- Mary Leakey - tip, must be activated on non-hostile foreign.
>
[Database.log](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/files/9673945/Database.log)
