### PR TITLE
English lang 5.1

### DIFF
--- a/lang/english.xml
+++ b/lang/english.xml
@@ -78,7 +78,7 @@
 		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_CITADEL_CIVILIZATION_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>+50% [ICON_Production] Production for 10 turns after liberating a city.</Text>
+			<Text>+50% [ICON_Production] Production for 10 [ICON_TURN] turns after liberating a city.</Text>
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_OUTBACK_STATION_DESCRIPTION" Language="en_US">
@@ -282,7 +282,7 @@
 		<!-- == ELEANOR (LEADER) == -->
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_ELEANOR_LOYALTY_DESCRIPTION" Language="en_US">
-			<Text>+100% [ICON_PRODUCTION] Production to Theater Square Buildings. Great Works in Eleanor’s cities each cause -1 Loyalty per turn in foreign cities within 9 tiles. A city that leaves another civilization due to a loss of Loyalty and is currently receiving the most Loyalty per turn from Eleanor's civilization skips the Free City step to join this civilization.[NEWLINE][NEWLINE]Great Works receive additional yields depending on the districts built in this city:[NEWLINE] +2 [ICON_SCIENCE] Science if a Campus is built.[NEWLINE] +2 [ICON_CULTURE] Culture if a Theater Square is built.[NEWLINE] +2 [ICON_GOLD] Gold if a Harbor or a Commercial Hub is built.[NEWLINE] +2 [ICON_FAITH] Faith if a Holy Site is built.[NEWLINE] +2 [ICON_PRODUCTION] Production if a Industrial Zone is built.[NEWLINE] +2 [ICON_FOOD] Food if a Neighborhood is built.[NEWLINE](Can't receive other bonus yields on great works by City-states)</Text>
+			<Text>+100% [ICON_PRODUCTION] Production to Theater Square Buildings. Great Works in Eleanor’s cities each cause -1 Loyalty per turn in foreign cities within 9 tiles. A city that leaves another civilization due to a loss of Loyalty and is currently receiving the most Loyalty per turn from Eleanor's civilization skips the Free City step to join this civilization.[NEWLINE][NEWLINE]Great Works receive additional yields depending on the districts built in this city:[NEWLINE] +1 [ICON_SCIENCE] Science if a Campus is built.[NEWLINE] +1 [ICON_CULTURE] Culture if a Theater Square is built.[NEWLINE] +1 [ICON_GOLD] Gold if a Harbor or a Commercial Hub is built.[NEWLINE] +1 [ICON_FAITH] Faith if a Holy Site is built.[NEWLINE] +1 [ICON_PRODUCTION] Production if a Industrial Zone is built.[NEWLINE] +1 [ICON_FOOD] Food if a Neighborhood is built.[NEWLINE](Can't receive other bonus yields on great works by City-states)</Text>
 		</Replace>
 
 		<!-- == ENGLAND == -->
@@ -323,26 +323,19 @@
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_ETHIOPIAN_OROMO_CAVALRY_DESCRIPTION" Language="en_US">
-			<Text>Ethiopian unique Medieval era light cavalry unit. Has additional sight and receives no [ICON_Movement] Movement penalty from moving in Hills and gains +4 [ICON_STRENGTH] Combat Strength when fighting in Hills.</Text>
+			<Text>Ethiopian unique Medieval era light cavalry unit. +1 [ICON_Movement] Movement if starts in Hills and +4 [ICON_STRENGTH] Combat Strength when fighting in Hills. Has Sight of 3.</Text>
 		</Replace>
 		<Replace Tag="LOC_UNIT_ETHIOPIAN_OROMO_CAVALRY_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>Ethiopian unique Medieval era light cavalry unit. Stronger and greater sight than the Courser that it replaces. Receives no [ICON_Movement] Movement penalty from movement in Hills and gains +4 [ICON_STRENGTH] Combat Strength when fighting in Hills.</Text>
+			<Text>Ethiopian unique Medieval era unit that replaces the Courser. +1 [ICON_Movement] Movement if starts in Hills and +4 [ICON_STRENGTH] Combat Strength when fighting in Hills. Has Sight of 3.</Text>
 		</Replace>
 		<Replace Tag="LOC_ABILITY_ETHIOPIAN_OROMO_CAVALRY_DESCRIPTION" Language="en_US">
-			<Text>Receives no movement penalty from movement in Hills.[NEWLINE][ICON_Bullet] +4 [ICON_STRENGTH] Combat Strength when fighting in Hills.</Text>
-		</Replace>
-		<!-- = unique improvement = -->
-		<Replace Tag="LOC_IMPROVEMENT_ROCK_HEWN_CHURCH_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>Unlocks the Builder ability to construct a Rock-Hewn Church, unique to Ethiopia.[NEWLINE][NEWLINE]+1 [ICON_Faith] Faith for every adjacent Hills tile. Provides [ICON_TOURISM] Tourism from [ICON_FAITH] Faith, after researching Flight. +1 Appeal. Can only be pillaged (never destroyed) by natural disasters. Can only be built on Hills or Volcanic Soil not adjacent to another Rock-Hewn Church.</Text>
-		</Replace>
-		<Replace Tag="LOC_IMPROVEMENT_ROCK_HEWN_CHURCH_DESCRIPTION" Language="en_US">
-			<Text>Unlocks the Builder ability to construct a Rock-Hewn Church, unique to Ethiopia.[NEWLINE][NEWLINE]+1 [ICON_Faith] Faith for every adjacent Hills tile. Provides [ICON_TOURISM] Tourism from [ICON_FAITH] Faith, after researching Flight. +1 Appeal. Can only be built on Hills not adjacent to another Rock-Hewn Church.</Text>
+			<Text>+1 [ICON_Movement] Movement if starts in Hills.[NEWLINE][ICON_Bullet] +4 [ICON_STRENGTH] Combat Strength when fighting in Hills.</Text>
 		</Replace>
 
 		<!-- == FRANCE == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_WONDER_TOURISM_DESCRIPTION" Language="en_US">
-			<Text>Receives a free Spy (and extra spy capacity) with the Castles technology. All spies start as Agents with a [ICON_Promotion] free promotion. +20% [ICON_Production] Production toward Medieval, Renaissance, and Industrial era wonders. [ICON_Tourism] Tourism from wonders of any era is +50%.</Text>
+			<Text>Receives a free Spy (and extra spy capacity) with the Castles technology. All spies start with a [ICON_Promotion] free promotion. +20% [ICON_Production] Production toward Medieval, Renaissance, and Industrial era Wonders. +50% [ICON_Tourism] Tourism from Wonders of any era.</Text>
 		</Replace>
 		<!-- = leader ability (Black Queen) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_FLYING_SQUADRON_DESCRIPTION" Language="en_US">
@@ -598,10 +591,10 @@
 		</Replace>
 		
 
-		<!-- == MACEDONIA == -->
+		<!-- == MACEDON == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_HELLENISTIC_FUSION_DESCRIPTION" Language="en_US">
-			<Text>Receive boosts upon city conquest: +20% [ICON_PRODUCTION] in all cities for 10 turns, as well as a [ICON_TechBoosted] Eureka for each Encampment or Campus in the conquered city and an [ICON_CivicBoosted] Inspiration for each Holy Site or Theater Square.</Text>
+			<Text>Receive boosts upon city conquest: +20% [ICON_PRODUCTION] in all cities for 10 [ICON_TURN] turns, as well as a [ICON_TechBoosted] Eureka for each Encampment or Campus in the conquered city and an [ICON_CivicBoosted] Inspiration for each Holy Site or Theater Square.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_LEADER_HELLENISTIC_FUSION_EXPANSION1_DESCRIPTION" Language="en_US">
 			<Text>Receive boosts upon city conquest: +20% [ICON_PRODUCTION] in all cities for 10 turns, as well as a [ICON_TechBoosted] Eureka for each Encampment or Campus in the conquered city and an [ICON_CivicBoosted] Inspiration for each Holy Site or Theater Square.</Text>
@@ -738,9 +731,16 @@
 		<Replace Tag="LOC_UNIT_SULEIMAN_JANISSARY_DESCRIPTION" Language="en_US">
 			<Text>Ottoman unique Renaissance Era unit that replaces the Musketman. Starts with a [ICON_Promotion] free promotion. Stronger and cheaper than the Musketman. To train a Janissary a city must have a population of at least 2. If a city is founded by the Ottomans and trains a Janissary it loses a population.</Text>
 		</Replace>
+		<!-- = unique unit = -->
+		<Replace Tag="LOC_UNIT_OTTOMAN_BARBARY_CORSAIR_DESCRIPTION" Language="en_US">
+			<Text>Ottoman unique Medieval era naval unit that replaces the Privateer. Can enter Ocean tiles regardless of researched Technologies. It costs no [ICON_Movement] Movement to coastal raid. Can only be seen by other Naval Raiders unless adjacent to it. Reveals Naval Raiders within sight range.</Text>
+		</Replace>
+		<Replace Tag="LOC_ABILITY_CORSAIR_DESCRIPTION" Language="en_US">
+			<Text>It costs no [ICON_Movement] Movement to coastal raid.[NEWLINE][ICON_Bullet] Can enter Ocean tiles regardless of researched Technologies.</Text>
+		</Replace>
 		<!-- = unique building = -->
 		<Replace Tag="LOC_BUILDING_GRAND_BAZAAR_DESCRIPTION" Language="en_US">
-			<Text>A building unique to the Ottomans. Accumulate 1 extra Strategic resource for every different type of Strategic resource this city has improved. Receive 1 [ICON_AMENITIES] Amenity for every Luxury resource this city has improved.[NEWLINE]+2 [ICON_GOLD] Gold for each [ICON_TRADEROUTE] trade routes from this city.[NEWLINE]+1 [ICON_GOLD] Gold for each [ICON_TRADEROUTE] trade routes to this city.[NEWLINE]+1 [ICON_TRADEROUTE] Trade route capacity.</Text>
+			<Text>A building unique to the Ottomans. Accumulate 1 extra Strategic resource for every different type of Strategic resource this city has improved. Receive 1 [ICON_AMENITIES] Amenity for every Luxury resource this city has improved. Grants [ICON_Governor] Governor Title when first constructed.[NEWLINE][NEWLINE]+1 [ICON_TRADEROUTE] Trade route capacity.[NEWLINE]+2 [ICON_GOLD] Gold for each [ICON_TRADEROUTE] trade routes from this city.[NEWLINE]+1 [ICON_GOLD] Gold for each [ICON_TRADEROUTE] trade routes to this city.</Text>
 		</Replace>
 
 		<!-- == PERSIA == -->
@@ -811,16 +811,7 @@
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_ROMAN_LEGION_DESCRIPTION" Language="en_US"> <!-- charge icon -->
-			<Text>Roman unique Classical era melee unit that replaces the Swordsman. Has 1 [ICON_Charges] charge to build a Roman Fort.</Text>		</Replace>
-		<!-- = unique district = -->
-		<Replace Tag="LOC_DISTRICT_BATH_DESCRIPTION" Language="en_US">
-			<Text>A district unique to Rome that replaces the Aqueduct district and is cheaper to build. +1 [ICON_Culture] Culture for every 2 adjacent districts.[NEWLINE][NEWLINE]It provides this city with a source of fresh water from an adjacent River, Lake, Oasis, or Mountain. Cities that do not yet have existing fresh water receive up to 6 [ICON_Housing] Housing. In all cases the Bath provides an additional bonus of +2 [ICON_Housing] Housing and +1 [ICON_Amenities] Amenity. Must be built adjacent to the City Center.</Text>
-		</Replace>
-		<Replace Tag="LOC_DISTRICT_BATH_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>A district unique to Rome that replaces the Aqueduct district and is cheaper to build. +1 [ICON_Culture] Culture for every 2 adjacent districts.[NEWLINE][NEWLINE]It provides this city with a source of fresh water from an adjacent River, Lake, Oasis, or Mountain. Cities that do not yet have existing fresh water receive up to 6 [ICON_Housing] Housing. Cities that already have existing fresh water will instead get +2 [ICON_Housing] Housing. If built adjacent to a Geothermal Fissure +1 [ICON_Amenities] Amenity. In all cases the Bath provides an additional bonus of +2 [ICON_Housing] Housing and +1 [ICON_Amenities] Amenity. Prevents [ICON_Food] Food loss during Drought. Must be built adjacent to the City Center.</Text>
-		</Replace>
-		<Replace Tag="LOC_DISTRICT_BATH_EXPANSION2_ALT_DESCRIPTION" Language="en_US">
-			<Text>A district unique to Rome that replaces the Aqueduct district and is cheaper to build. +1 [ICON_Culture] Culture for every 2 adjacent districts.[NEWLINE][NEWLINE]It provides this city with a source of fresh water from an adjacent River, Lake, Oasis, or Mountain. Cities that do not yet have existing fresh water receive up to 6 [ICON_Housing] Housing. Cities that already have existing fresh water will instead get +2 [ICON_Housing] Housing. If built adjacent to a Geothermal Fissure +1 [ICON_Amenities] Amenity. In all cases the Bath provides an additional bonus of +2 [ICON_Housing] Housing and +1 [ICON_Amenities] Amenity. Prevents [ICON_Food] Food loss during Drought. Must be built adjacent to the City Center.</Text>
+			<Text>Roman unique Classical era melee unit that replaces the Swordsman. Has 1 [ICON_Charges] charge to build a Roman Fort.</Text>
 		</Replace>
 
 		<!-- == RUSSIA == -->
@@ -842,11 +833,11 @@
 
 		<!-- == SCOTLAND == -->
 		<!-- = unique improvement = -->
-		<Replace Tag="LOC_IMPROVEMENT_GOLF_COURSE_DESCRIPTION" Language="en_US"> <!-- Last update: 4.2.0-->
-			<Text>Unlocks the Builder ability to construct a Golf Course, unique to Scotland.[NEWLINE][NEWLINE]+1 [ICON_AMENITIES] Amenity, +2 [ICON_GOLD] Gold, and +1 [ICON_CULTURE] Culture. +1 [ICON_GOLD] Gold and +1 [ICON_CULTURE] Culture if adjacent to a City Center district. +1 [ICON_AMENITIES] Amenity and +1 [ICON_CULTURE] Culture if adjacent to an Entertainment Complex district. Additional [ICON_CULTURE] Culture, [ICON_GOLD] Gold, [ICON_TOURISM] Tourism, and [ICON_HOUSING] Housing as you advance through the Civics and Technology Trees. Cannot be placed on Desert or Desert Hills. One per City. Tiles with Golf Courses cannot be swapped. +1 Appeal.</Text>
+		<Replace Tag="LOC_IMPROVEMENT_GOLF_COURSE_DESCRIPTION" Language="en_US">
+			<Text>Unlocks the Builder ability to construct a Golf Course, unique to Scotland.[NEWLINE][NEWLINE]+1 [ICON_AMENITIES] Amenity, +2 [ICON_GOLD] Gold, +1 [ICON_CULTURE] Culture and +1 Appeal to adjacent tiles. +1 [ICON_GOLD] Gold and +1 [ICON_CULTURE] Culture if adjacent to a City Center district. +1 [ICON_AMENITIES] Amenity and +1 [ICON_CULTURE] Culture if adjacent to an Entertainment Complex district. Additional [ICON_CULTURE] Culture, [ICON_GOLD] Gold, [ICON_TOURISM] Tourism, and [ICON_HOUSING] Housing as you advance through the Civics and Technology Trees.[NEWLINE][NEWLINE]Cannot be placed on Desert or Desert Hills. One per City. Tiles with Golf Courses cannot be swapped.</Text>
 		</Replace>
-		<Replace Tag="LOC_IMPROVEMENT_GOLF_COURSE_XP2_DESCRIPTION" Language="en_US"> <!-- Last update: 4.2.0-->
-			<Text>Unlocks the Builder ability to construct a Golf Course, unique to Scotland.[NEWLINE][NEWLINE]+1 [ICON_AMENITIES] Amenity, +2 [ICON_GOLD] Gold, and +1 [ICON_CULTURE] Culture. +1 [ICON_GOLD] Gold and +1 [ICON_CULTURE] Culture if adjacent to a City Center district. +1 [ICON_AMENITIES] Amenity and +1 [ICON_CULTURE] Culture if adjacent to an Entertainment Complex district. Additional [ICON_CULTURE] Culture, [ICON_GOLD] Gold, [ICON_TOURISM] Tourism, and [ICON_HOUSING] Housing as you advance through the Civics and Technology Trees. Cannot be placed on Desert or Desert Hills. One per City. Tiles with Golf Courses cannot be swapped. +1 Appeal.</Text>
+		<Replace Tag="LOC_IMPROVEMENT_GOLF_COURSE_XP2_DESCRIPTION" Language="en_US">
+			<Text>Unlocks the Builder ability to construct a Golf Course, unique to Scotland.[NEWLINE][NEWLINE]+1 [ICON_AMENITIES] Amenity, +2 [ICON_GOLD] Gold, +1 [ICON_CULTURE] Culture and +1 Appeal to adjacent tiles. +1 [ICON_GOLD] Gold and +1 [ICON_CULTURE] Culture if adjacent to a City Center district. +1 [ICON_AMENITIES] Amenity and +1 [ICON_CULTURE] Culture if adjacent to an Entertainment Complex district. Additional [ICON_CULTURE] Culture, [ICON_GOLD] Gold, [ICON_TOURISM] Tourism, and [ICON_HOUSING] Housing as you advance through the Civics and Technology Trees.[NEWLINE][NEWLINE]Cannot be placed on Desert or Desert Hills. One per City. Tiles with Golf Courses cannot be swapped.</Text>
 		</Replace>
 
 		<!-- == SCYTHIA == -->
@@ -880,10 +871,10 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_MISSION_DESCRIPTION" Language="en_US">
-			<Text>Unlocks the Builder ability to construct a Mission, unique to Spain.[NEWLINE][NEWLINE]+2 [ICON_Faith] Faith. +1 [ICON_Faith] Faith if built at least 8 tiles away from [ICON_CAPITAL] Capital, otherwise +1 [ICON_HOUSING] Housing.[NEWLINE][NEWLINE]+2 [ICON_Science] Science if built next to a Campus district. +2 Science at The Enlightenment. Cannot be built next to another Mission.</Text>
+			<Text>Unlocks the Builder ability to construct a Mission, unique to Spain.[NEWLINE][NEWLINE]+2 [ICON_Faith] Faith. +1 [ICON_Faith] Faith if built at least 8 tiles away from [ICON_CAPITAL] Capital, otherwise +1 [ICON_HOUSING] Housing.[NEWLINE]+2 [ICON_Science] Science if built next to a Campus district. +2 [ICON_Science] Science at The Enlightenment.[NEWLINE][NEWLINE]Cannot be built next to another Mission.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_MISSION_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>Unlocks the Builder ability to construct a Mission, unique to Spain.[NEWLINE][NEWLINE]+2 [ICON_Faith] Faith. +1 [ICON_Faith] Faith and +1 [ICON_PRODUCTION] Production if built at least 8 tiles away from [ICON_CAPITAL] Capital, otherwise +1 [ICON_HOUSING] Housing.[NEWLINE][NEWLINE]+1 [ICON_Science] Science for every adjacent Campus and Holy Site district. +2 Science at The Enlightenment. Cannot be built next to another Mission.</Text>
+			<Text>Unlocks the Builder ability to construct a Mission, unique to Spain.[NEWLINE][NEWLINE]+2 [ICON_Faith] Faith. +1 [ICON_Faith] Faith and +1 [ICON_PRODUCTION] Production if built at least 8 tiles away from current [ICON_CAPITAL] Capital, otherwise +1 [ICON_HOUSING] Housing.[NEWLINE]+1 [ICON_Science] Science for every adjacent Campus and Holy Site district. +2 [ICON_Science] Science at The Enlightenment.[NEWLINE][NEWLINE]Cannot be built next to another Mission.</Text>
 		</Replace>
 
 		<!-- == SUMERIA == -->
@@ -997,6 +988,18 @@
 		<Replace Tag="LOC_UNIT_TRADER_DESCRIPTION" Language="en_US"> <!-- embarkation tip -->
 			<Text>May make and maintain a single [ICON_TradeRoute] Trade Route. Automatically creates Roads as it travels. Can embark since Celestial Navigation technology is researched.</Text>
 		</Replace>
+		<Replace Tag="LOC_UNIT_QUADRIREME_DESCRIPTION" Language="en_US">
+			<Text>Classical era ranged naval unit with [ICON_Range] Range of 1. Can only operate on Coastal waters until Cartography is researched.</Text>
+		</Replace>
+		<Replace Tag="LOC_UNIT_FRIGATE_DESCRIPTION" Language="en_US">
+			<Text>Renaissance era ranged naval unit with [ICON_Range] Range of 2.</Text>
+		</Replace>
+		<Replace Tag="LOC_UNIT_BATTLESHIP_DESCRIPTION" Language="en_US">
+			<Text>Modern era naval ranged unit with [ICON_Range] Range of 3. Provides cover from air and nuclear attacks up to 1 tile away.</Text>
+		</Replace>
+		<Replace Tag="LOC_UNIT_MISSILE_CRUISER_DESCRIPTION" Language="en_US">
+			<Text>Information era ranged naval unit with [ICON_Range] Range of 4. Provides cover from air and nuclear attacks up to 1 tile away.</Text>
+		</Replace>
 
 
 
@@ -1046,6 +1049,9 @@
 		<Replace Tag="LOC_PROMOTION_ARROW_STORM_DESCRIPTION" Language="en_US">
 			<Text>+7 [ICON_Ranged] Ranged Strength when attacking.</Text>
 		</Replace>
+		<Replace Tag="LOC_PROMOTION_MONK_DISCIPLES_DESCRIPTION" Language="en_US">
+			<Text>When defeats non-barbarian unit, spreads 250 Religious pressure within 6 tiles.</Text>
+		</Replace>
 
 
 
@@ -1059,6 +1065,9 @@
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_EMBRASURE_DESCRIPTION" Language="en_US">
 			<Text>City gains an additional [ICON_Ranged] Ranged Strike per turn. Military units trained in this city start with a [ICON_Promotion] free promotion that do not already start with a [ICON_Promotion] free promotion.</Text>
+		</Replace>
+		<Replace Tag="LOC_GOVERNOR_PROMOTION_AIR_DEFENSE_INITIATIVE_DESCRIPTION" Language="en_US">
+			<Text>+25 [ICON_ANTIAIR_LARGE] Combat Strength to anti-air support units within the city's territory when defending against aircraft and ICBMs.</Text>
 		</Replace>
 
 		<!-- == Reyna == -->
@@ -1134,6 +1143,9 @@
 		<Replace Tag="LOC_GOVERNOR_THE_EDUCATOR_DESCRIPTION" Language="en_US">
 			<Text>{LOC_GOVERNOR_THE_EDUCATOR_NAME} is focused on the cultivation of [ICON_SCIENCE] Scientific endeavors in the city. He is also quite skilled in the attraction of [ICON_GreatPerson] Great People to his city.</Text>
 		</Replace>
+		<Replace Tag="LOC_GOVERNOR_PROMOTION_EDUCATOR_GRANTS_DESCRIPTION" Language="en_US">
+			<Text>+100% [ICON_GreatPerson] Great People points generated per turn in the city by districts, buildings, pantheons and World Wonders.</Text>
+		</Replace>
 		
 		<!-- == Amani == -->
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_AMBASSADOR_AFFLUENCE_DESCRIPTION" Language="en_US">
@@ -1163,6 +1175,11 @@
 			<Text>Settlers trained in the city do not consume a [ICON_Citizen] Population and gain +1 [ICON_Movement] Movement.</Text>
 		</Replace>
 
+		<!-- == Ibrahim == -->
+		<Replace Tag="LOC_GOVERNOR_PROMOTION_CAPOU_AGHA_DESCRIPTION" Language="en_US">
+			<Text>All friendly units within 10 tiles of the City Center gain +1 [ICON_Movement] Movement.</Text>
+		</Replace>
+
 
 
 		<!-- === PANTHEONS === -->
@@ -1170,7 +1187,7 @@
 			<Text>+3 [ICON_Faith] Faith and +3 [ICON_GOLD] Gold from Mines over Luxury and Bonus resources.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_DIVINE_SPARK_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>[ICON_GreatPerson] +1 Great Person points for each Holy Site (Prophet), Campus (Scientist), Amphiteater (Writer) and Industrial Zone (Engineer).</Text>
+			<Text>+1 [ICON_GreatPerson] Great Person point for Holy Site ([ICON_GreatProphet] Great Prophet), Campus ([ICON_GreatScientist] Great Scientist) and Industrial Zone ([ICON_GreatEngineer] Great Engineer) districts, Amphiteater ([ICON_GreatWriter] Great Writer) building.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_FERTILITY_RITES_DESCRIPTION" Language="en_US">
 			<Text>+1 [ICON_FOOD] Food for [ICON_RESOURCE_CATTLE] Cattle, [ICON_RESOURCE_RICE] Rice, and [ICON_RESOURCE_WHEAT] Wheat tiles.</Text>
@@ -1194,7 +1211,7 @@
 			<Text>+1 [ICON_Production] Production and +1 [ICON_Faith] Faith from Quarries.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_CITY_PATRON_GODDESS_DESCRIPTION" Language="en_US">
-			<Text>+50% [ICON_Production] Production toward all districts in cities without a specialty district.</Text>
+			<Text>+50% [ICON_Production] Production toward all [ICON_DISTRICT] districts in cities without a specialty [ICON_DISTRICT] district.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_DANCE_OF_THE_AURORA_DESCRIPTION" Language="en_US">
 			<Text>Holy Site districts get +1 [ICON_Faith] Faith from adjacent flat Tundra tiles.</Text>
@@ -1224,7 +1241,7 @@
 			<Text>God of War and Plunder</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_GOD_OF_WAR_DESCRIPTION" Language="en_US">
-			<Text>+1 [ICON_GreatPerson] Great Person point from Encampment (General), Harbor (Admiral), and Commerical Hub (Merchant) districts.</Text>
+			<Text>+1 [ICON_GreatPerson] Great Person point for Encampment ([ICON_GreatGeneral] Great General), Harbor ([ICON_GREATADMIRAL] Great Admiral), and Commerical Hub ([ICON_GreatMerchant] Great Merchant) districts.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_GOD_OF_THE_FORGE_DESCRIPTION" Language="en_US">
 			<Text>+30% [ICON_Production] Production toward Ancient and Classical military units.</Text>
@@ -1234,6 +1251,12 @@
 		</Replace>
 		<Replace Tag="LOC_BELIEF_EARTH_GODDESS_EXPANSION2_DESCRIPTION" Language="en_US">
 			<Text>+1 Faith [ICON_Faith] from tiles with Charming or better Appeal.</Text>
+		</Replace>
+		<Replace Tag="LOC_BELIEF_GODDESS_OF_THE_HUNT_DESCRIPTION" Language="en_US">
+			<Text>+1 [ICON_Production] Production and +2 [ICON_GOLD] Gold from Camps.</Text>
+		</Replace>
+		<Replace Tag="LOC_BELIEF_GODDESS_OF_THE_HUNT_EXPANSION2_DESCRIPTION" Language="en_US">
+			<Text>+1 [ICON_Production] Production and +2 [ICON_GOLD] Gold from Camps.</Text>
 		</Replace>
 
 
@@ -1333,6 +1356,9 @@
 		<Replace Tag="LOC_IMPROVEMENT_FISHERY_DESCRIPTION" Language="en_US">
 			<Text>Unlocks the Builder ability to construct Fisheries.[NEWLINE][NEWLINE]+1 [ICON_Food] Food, +1 additional [ICON_Food] Food if adjacent to a sea resource. Must be built on a coastal plot.</Text>
 		</Replace>
+		<Replace Tag="LOC_ROUTE_RAILROAD_DESCRIPTION" Language="en_US">
+			<Text>Can only be constructed by Military Engineers. Does not cost a charge, but does cost 2 [ICON_RESOURCE_IRON] Iron and 1 [ICON_RESOURCE_COAL] Coal.[NEWLINE][NEWLINE]Greatly improves [ICON_Movement] Movement speed of any unit moving from one Railroad tile to another. [ICON_TradeRoute] Trade Routes traveling over Railroads can multiply the [ICON_Gold] Gold they get from districts at their destination.</Text>
+		</Replace>
 		
 
 
@@ -1343,20 +1369,23 @@
 		<Replace Tag="LOC_BUILDING_CONSULATE_DESCRIPTION" Language="en_US">
 			<Text>+2 [ICON_InfluencePerTurn] Influence Points per turn. Enemy Spy's level is reduced by 1 when targeting this city or cities with Encampments.</Text>
 		</Replace>
-		<Replace Tag="LOC_BUILDING_GOV_CITYSTATES_DESCRIPTION" Language="en_US">
-			<Text>Leveraging City-states costs half [ICON_Gold] Gold. City-state units gain +4 [ICON_Strength] Combat Strength if you are the City-state's Suzerain (including Leveraged Units).[NEWLINE]Awards +1 [Icon_Governor] Governor Title, +2 [ICON_Envoy] Envoys and +2 [ICON_InfluencePerTurn] Influence Points per turn.</Text>
-		</Replace>
-		<Replace Tag="LOC_BUILDING_GOV_CITYSTATES_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>+3 [ICON_Favor] Diplomatic Favor. Leveraging City-states costs half [ICON_Gold] Gold. City-state units gain +4 [ICON_Strength] Combat Strength if you are the City-state's Suzerain (including Leveraged Units).[NEWLINE]Awards +1 [Icon_Governor] Governor Title, +2 [ICON_Envoy] Envoys and +2 [ICON_InfluencePerTurn] Influence Points per turn.</Text>
-		</Replace>
 		<Replace Tag="LOC_BUILDING_GOV_TALL_DESCRIPTION" Language="en_US">
-			<Text>+1 [ICON_Amenities] Amenity, +2 [ICON_FOOD] Food, and +3 [ICON_Housing] Housing in Cities with [ICON_Governor] Governors[NEWLINE]-2 Loyalty in Cities without [ICON_Governor] Governors.[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
+			<Text>+1 [ICON_Amenities] Amenity, +2 [ICON_FOOD] Food, and +3 [ICON_Housing] Housing in Cities with a [ICON_Governor] Governor. -2 Loyalty in Cities without a [ICON_Governor] Governor.[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_GOV_CONQUEST_DESCRIPTION" Language="en_US">
-			<Text>+25% [ICON_Production] Production towards all naval and land military units. Reduces the maintenance cost of units by 1 [ICON_GOLD] Gold.[NEWLINE]Awards +1 [Icon_Governor] Governor Title and increases Strategic Resources stockpiles by 15.</Text>
+			<Text>+25% [ICON_Production] Production towards all naval and land military units in all cities. Reduces the maintenance cost of units by 1 [ICON_GOLD] Gold. Increases Strategic Resources stockpiles by 15 (on Online speed).[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_GOV_CITYSTATES_DESCRIPTION" Language="en_US">
+			<Text>+2 [ICON_InfluencePerTurn] Influence Points per turn. Leveraging City-states costs half [ICON_Gold] Gold. City-state units gain +4 [ICON_Strength] Combat Strength if you are the City-state's Suzerain (including Leveraged Units).[NEWLINE]Awards +1 [Icon_Governor] Governor Title and +2 [ICON_Envoy] Envoys.</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_GOV_CITYSTATES_EXPANSION2_DESCRIPTION" Language="en_US">
+			<Text>+3 [ICON_Favor] Diplomatic Favor per turn and +2 [ICON_InfluencePerTurn] Influence Points per turn. Leveraging City-states costs half [ICON_Gold] Gold. City-state units gain +4 [ICON_Strength] Combat Strength if you are the City-state's Suzerain (including Leveraged Units).[NEWLINE]Awards +1 [Icon_Governor] Governor Title and +2 [ICON_Envoy] Envoys.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_GOV_FAITH_DESCRIPTION" Language="en_US">
 			<Text>Grants the ability to buy land units with [ICON_Faith] Faith in all owned cities.[NEWLINE]Pillaging Improvements and Districts provides bonus [ICON_Faith] Faith.[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_GOV_SPIES_DESCRIPTION" Language="en_US">
+			<Text>+50% [ICON_PRODUCTION] toward Spies. All Spy Operations have a higher chance of success.[NEWLINE]Awards +1 [Icon_Governor] Governor Title, +2 Spy capacity and Spy unit.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_GOV_SCIENCE_DESCRIPTION" Language="en_US">
 			<Text>Builders and Military Engineers gain the ability to use all of their [ICON_Charges] charges to provide bonus [ICON_Production] Production to a District Project. Each [ICON_Charges] charge grants 2% of project [ICON_Production] Production. Once per city per turn.[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
@@ -1497,6 +1526,12 @@
 		</Replace>
 		<Replace Tag="LOC_BUILDING_PYRAMIDS_DESCRIPTION" Language="en_US">
 			<Text>Grants a free Builder and +1 [ICON_Charges] charge for all existing and new Builders.[NEWLINE][NEWLINE]Must be built on flat Desert tile (including Floodplains).</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_STATUE_OF_ZEUS_DESCRIPTION" Language="en_US">
+			<Text>Grants 3 Archers, 3 Spearmen, and a Battering Ram. +35% [ICON_PRODUCTION] Production towards anti-cavalry units.[NEWLINE][NEWLINE]Must be built on flat land adjacent to an Encampment district with a Barracks.</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_ORSZAGHAZ_DESCRIPTION" Language="en_US">
+			<Text>+1 [ICON_Favor] Diplomatic Favor per City-State you are the Suzerain of.[NEWLINE][NEWLINE]Must be built on a River.</Text>
 		</Replace>
 		
 
@@ -1683,7 +1718,7 @@
 			<Text>Trench Warfare</Text>
 		</Replace>
 		<Replace Tag="LOC_POLICY_TRENCH_WARFARE_DESCRIPTION" Language="en_US">
-			<Text>+50% [ICON_Production] Production toward siege units.</Text>
+			<Text>+50% [ICON_Production] Production toward all siege units.</Text>
 		</Replace>
 		<Replace Tag="LOC_PEDIA_GOVERNMENTS_PAGE_POLICY_TRENCH_WARFARE_CHAPTER_HISTORY_PARA_1" Language="en_US">
 			<Text>Trench warfare is a type of land warfare using occupied fighting lines largely comprising military trenches, in which troops are well-protected from the enemy's small arms fire and are substantially sheltered from artillery. Trench warfare became archetypically associated with the World War I (1914–1918), when the Race to the Sea rapidly expanded trench use on the Western Front starting in September 1914.[NEWLINE]Trench warfare proliferated when a revolution in firepower was not matched by similar advances in mobility, resulting in a gruelling form of warfare in which the defender held the advantage. On the Western Front in 1914–1918, both sides constructed elaborate trench, underground, and dugout systems opposing each other along a front, protected from assault by barbed wire. The area between opposing trench lines (known as "no man's land") was fully exposed to artillery fire from both sides. Attacks, even if successful, often sustained severe casualties. </Text>
@@ -1734,8 +1769,21 @@
 			<Text>Spies who steal a [ICON_TechBoosted] tech boost without being detected gain an extra [ICON_TechBoosted] boost.</Text>
 		</Replace>
 		<Replace Tag="LOC_POLICY_INSULAE_DESCRIPTION" Language="en_US">
-			<Text>+1 [ICON_Housing] Housing in all cities with at least 1 specialty district.</Text>
+			<Text>+1 [ICON_Housing] Housing in all cities with at least 1 [ICON_DISTRICT] specialty district.</Text>
 		</Replace>
+		<Replace Tag="LOC_POLICY_MEDINA_QUARTER_DESCRIPTION" Language="en_US">
+			<Text>+2 [ICON_Housing] Housing in all cities with at least 3 [ICON_DISTRICT] specialty districts.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_LIBERALISM_DESCRIPTION" Language="en_US">
+			<Text>+1 [ICON_Amenities] Amenity to all cities with at least 2 [ICON_DISTRICT] specialty districts.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_NEW_DEAL_DESCRIPTION" Language="en_US">
+			<Text>+4 [ICON_Housing] Housing, +2 [ICON_Amenities] Amenities, -8 [ICON_Gold] Gold to all cities with at least 3 [ICON_DISTRICT] specialty districts.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_NEW_DEAL_DESCRIPTION_XP2" Language="en_US">
+			<Text>+4 [ICON_Housing] Housing and +2 [ICON_Amenities] Amenities to all cities with at least 3 [ICON_DISTRICT] specialty districts.</Text>
+		</Replace>
+
 		<Replace Tag="LOC_POLICY_ROGUE_STATE_DESCRIPTION" Language="en_US">
 			<Text>+50% [ICON_Production] Production to nuclear program projects and Nuclear Devices.[NEWLINE]BUT: Earn no [ICON_InfluencePerTurn] Influence Points per turn.</Text>
 		</Replace>
@@ -1754,6 +1802,55 @@
 		</Replace>
 		<Replace Tag="LOC_GOVT_ACCUMULATED_BONUS_BRIEF_FASCISM_XP1" Language="en_US">
 			<Text>+50% [ICON_Production] Production toward Units.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_AGOGE_DESCRIPTION" Language="en_US">
+			<Text>+50% [ICON_Production] Production toward Classical era and earlier melee, recon, anti-cavalry, and ranged units.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FEUDAL_CONTRACT_DESCRIPTION" Language="en_US">
+			<Text>+50% [ICON_Production] Production toward Renaissance era and earlier melee, recon, anti-cavalry, and ranged units.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_GRANDE_ARMEE_DESCRIPTION" Language="en_US">
+			<Text>+50% [ICON_Production] Production toward Industrial era and earlier melee, recon, anti-cavalry, and ranged units.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_MILITARY_FIRST_DESCRIPTION" Language="en_US">
+			<Text>+50% [ICON_Production] Production toward all melee, recon, anti-cavalry, and ranged units.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_SERFDOM_DESCRIPTION" Language="en_US">
+			<Text>Newly trained Builders gain +2 [ICON_Charges] charges.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_PUBLIC_WORKS_DESCRIPTION" Language="en_US">
+			<Text>+30% [ICON_Production] Production toward Builders, and newly trained Builders gain +2 [ICON_Charges] charges.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_LOGISTICS_DESCRIPTION" Language="en_US">
+			<Text>+1 [ICON_Movement] Movement if starting turn in friendly territory.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FUTURE_VICTORY_DOMINATION_DESCRIPTION" Language="en_US">
+			<Text>+1 [ICON_Movement] Movement if starting turn in enemy territory. +50% [ICON_Production] Production for Giant Death Robots.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_PUBLIC_TRANSPORT_DESCRIPTION_XP2" Language="en_US">
+			<Text>Neighborhoods with Charming appeal receive +3 [ICON_Food] Food and +1 [ICON_Production] Production, Neighborhoods with Breathtaking appeal receive additional +1 [ICON_Food] Food and +1 [ICON_Production] Production. All Neighborhoods receive +1 [ICON_Gold] Gold.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_GOTHIC_ARCHITECTURE_DESCRIPTION" Language="en_US">
+			<Text>+15% [ICON_Production] Production toward Renaissance era and earlier wonders.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_WISSELBANKEN_DESCRIPTION" Language="en_US">
+			<Text>Your [ICON_TradeRoute] Trade Routes to an Ally's city or vassal city-state provide +2 [ICON_Food] Food and +2 [ICON_Production] Production for both cities. +0.25 Alliance Points per turn for all Alliances.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_MACHIAVELLIANISM_DESCRIPTION" Language="en_US">
+			<Text>+50% [ICON_Production] Production toward Spies. Spy operations take 25% [ICON_TURN] less time.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_CONTAINMENT_DESCRIPTION" Language="en_US">
+			<Text>Each [ICON_Envoy] Envoy you send to a city-state counts as two, if its Suzerain has a different [ICON_Government] government than you.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FUTURE_VICTORY_CULTURE_DESCRIPTION" Language="en_US">
+			<Text>Your Rock Band units can choose from any possible [ICON_Promotion] promotion.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FUTURE_COUNTER_SCIENCE_DESCRIPTION" Language="en_US">
+			<Text>Your Spy units can choose from any possible [ICON_Promotion] promotion.</Text>
+		</Replace>
+
+		<Replace Tag="LOC_POLICY_PRESS_GANGS_DESCRIPTION" Language="en_US">
+			<Text>+100% [ICON_Production] Production toward Industrial era and earlier naval units.</Text>
 		</Replace>
 
 

--- a/lang/english.xml
+++ b/lang/english.xml
@@ -234,6 +234,10 @@
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_CREE_TRADE_GAIN_TILES_DESCRIPTION" Language="en_US">
 			<Text>+1 [ICON_TradeRoute] Trade Route capacity with the Pottery technology. Unclaimed tiles within 3 tiles of a Cree city come under Cree control when a Trader first moves into them.</Text>
 		</Replace>
+		<!-- = unique unit = -->
+		<Replace Tag="LOC_UNIT_CREE_OKIHTCITAW_DESCRIPTION" Language="en_US">
+			<Text>Cree unique Ancient era unit that replaces the Scout. Starts with a [ICON_Promotion] free promotion.</Text>
+		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_MEKEWAP_DESCRIPTION" Language="en_US">
 			<Text>Unlocks the Builder ability to construct a Mekewap, unique to Cree.[NEWLINE][NEWLINE]Provides +1 [ICON_PRODUCTION] Production and +1 [ICON_Housing] Housing. +1 [ICON_GOLD] Gold if adjacent to a Luxury resource. +1 [ICON_FOOD] Food for every 2 adjacent Bonus Resources. Additional +1 [ICON_Housing] Housing with Civil Service civic. Additional [ICON_PRODUCTION] Production, [ICON_GOLD] Gold, and [ICON_FOOD] Food as you advance through the Civics and Technology Tree.[NEWLINE][NEWLINE]Must be placed adjacent to a Bonus or Luxury resource. Cannot be built adjacent to another Mekewap.</Text>
@@ -807,7 +811,7 @@
 		<!-- == ROME == -->
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_TRAJANS_COLUMN_DESCRIPTION" Language="en_US">
-			<Text>All cities start with an additional City Center building after unlocking Code of Laws. (Starts with a Monument building in the Ancient era).</Text>
+			<Text>All cities start with Monument building after unlocking Code of Laws.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_ROMAN_LEGION_DESCRIPTION" Language="en_US"> <!-- charge icon -->
@@ -857,10 +861,10 @@
 		<!-- == SPAIN == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_TREASURE_FLEET_DESCRIPTION" Language="en_US">
-			<Text>May form Fleets and Armadas earlier than usual (Mercenaries and Mercantilism). Can create fleet and armada faster in cities with a shipyard.[NEWLINE][NEWLINE][ICON_TradeRoute] Trade Routes receive +3 [ICON_Gold] Gold, +2 [ICON_Faith] Faith, and +1 [ICON_Production] Production. [ICON_TradeRoute] Trade Routes between multiple continents receive double these numbers. Cities at least 8 tiles away from [ICON_CAPITAL] Capital receive +25% [ICON_Production] Production towards districts.</Text>
+			<Text>May form [ICON_Corps] Fleets and [ICON_Army] Armadas earlier than usual (Mercenaries and Mercantilism). Can create [ICON_Corps] Fleets and [ICON_Army] Armadas faster in cities with a shipyard.[NEWLINE][NEWLINE][ICON_TradeRoute] Trade Routes receive +3 [ICON_Gold] Gold, +2 [ICON_Faith] Faith, and +1 [ICON_Production] Production. [ICON_TradeRoute] Trade Routes between multiple continents receive double these numbers. Cities at least 8 tiles away from [ICON_CAPITAL] Capital receive +25% [ICON_Production] Production towards districts.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_TREASURE_FLEET_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>May form Fleets and Armadas earlier than usual (Mercenaries and Mercantilism). Can create fleet and armada faster in cities with a shipyard.[NEWLINE][NEWLINE][ICON_TradeRoute] Trade Routes receive +3 [ICON_Gold] Gold, +2 [ICON_Faith] Faith, and +1 [ICON_Production] Production. [ICON_TradeRoute] Trade Routes between multiple continents receive double these numbers. Cities at least 8 tiles away from [ICON_CAPITAL] Capital receive +25% [ICON_Production] Production towards districts.</Text>
+			<Text>May form [ICON_Corps] Fleets and [ICON_Army] Armadas earlier than usual (Mercenaries and Mercantilism). Can create [ICON_Corps] Fleets and [ICON_Army] Armadas faster in cities with a shipyard.[NEWLINE][NEWLINE][ICON_TradeRoute] Trade Routes receive +3 [ICON_Gold] Gold, +2 [ICON_Faith] Faith, and +1 [ICON_Production] Production. [ICON_TradeRoute] Trade Routes between multiple continents receive double these numbers. Cities at least 8 tiles away from [ICON_CAPITAL] Capital receive +25% [ICON_Production] Production towards districts.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_SPANISH_CONQUISTADOR_DESCRIPTION" Language="en_US">
@@ -871,7 +875,7 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_MISSION_DESCRIPTION" Language="en_US">
-			<Text>Unlocks the Builder ability to construct a Mission, unique to Spain.[NEWLINE][NEWLINE]+2 [ICON_Faith] Faith. +1 [ICON_Faith] Faith if built at least 8 tiles away from [ICON_CAPITAL] Capital, otherwise +1 [ICON_HOUSING] Housing.[NEWLINE]+2 [ICON_Science] Science if built next to a Campus district. +2 [ICON_Science] Science at The Enlightenment.[NEWLINE][NEWLINE]Cannot be built next to another Mission.</Text>
+			<Text>Unlocks the Builder ability to construct a Mission, unique to Spain.[NEWLINE][NEWLINE]+2 [ICON_Faith] Faith. +1 [ICON_Faith] Faith if built at least 8 tiles away from current [ICON_CAPITAL] Capital, otherwise +1 [ICON_HOUSING] Housing.[NEWLINE]+2 [ICON_Science] Science if built next to a Campus district. +2 [ICON_Science] Science at The Enlightenment.[NEWLINE][NEWLINE]Cannot be built next to another Mission.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_MISSION_EXPANSION2_DESCRIPTION" Language="en_US">
 			<Text>Unlocks the Builder ability to construct a Mission, unique to Spain.[NEWLINE][NEWLINE]+2 [ICON_Faith] Faith. +1 [ICON_Faith] Faith and +1 [ICON_PRODUCTION] Production if built at least 8 tiles away from current [ICON_CAPITAL] Capital, otherwise +1 [ICON_HOUSING] Housing.[NEWLINE]+1 [ICON_Science] Science for every adjacent Campus and Holy Site district. +2 [ICON_Science] Science at The Enlightenment.[NEWLINE][NEWLINE]Cannot be built next to another Mission.</Text>
@@ -890,13 +894,13 @@
 			<Text>Shūtur eli sharrī</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_LEADER_ADVENTURES_ENKIDU_DESCRIPTION" Language="en_US">
-			<Text>Military Units receive bonus [ICON_STRENGTH] Combat Strength equal to the level of your most advanced Alliance (maximum 3).[NEWLINE][NEWLINE]When at war with a common foe, they and their allies share pillage rewards and combat experience gains if within 5 tiles. Their Alliances gain Alliance Points for being at war with a common foe.[NEWLINE][NEWLINE]When you capture a Barbarian Outpost, receive a Tribal Village reward in addition to the usual [ICON_Gold] Gold. Pay half the usual cost to levy City-state units.</Text>
+			<Text>Starts game with War-cart instead of Warrior unit.[NEWLINE][NEWLINE]Military Units receive bonus [ICON_STRENGTH] Combat Strength equal to the level of your most advanced Alliance (maximum 3).[NEWLINE][NEWLINE]When at war with a common foe, they and their allies share pillage rewards and combat experience gains if within 5 tiles. Their Alliances gain Alliance Points for being at war with a common foe.[NEWLINE][NEWLINE]When you capture a Barbarian Outpost, receive a Tribal Village reward in addition to the usual [ICON_Gold] Gold. Pay half the usual cost to levy City-state units.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_LEADER_ADVENTURES_ENKIDU_EXPANSION1_DESCRIPTION" Language="en_US">
-			<Text>Military Units receive bonus [ICON_STRENGTH] Combat Strength equal to the level of your most advanced Alliance (maximum 3).[NEWLINE][NEWLINE]When at war with a common foe, they and their allies share pillage rewards and combat experience gains if within 5 tiles. Their Alliances gain Alliance Points for being at war with a common foe.[NEWLINE][NEWLINE]When you capture a Barbarian Outpost, receive a Tribal Village reward in addition to the usual [ICON_Gold] Gold. Pay half the usual cost to levy City-state units.</Text>
+			<Text>Starts game with War-cart instead of Warrior unit.[NEWLINE][NEWLINE]Military Units receive bonus [ICON_STRENGTH] Combat Strength equal to the level of your most advanced Alliance (maximum 3).[NEWLINE][NEWLINE]When at war with a common foe, they and their allies share pillage rewards and combat experience gains if within 5 tiles. Their Alliances gain Alliance Points for being at war with a common foe.[NEWLINE][NEWLINE]When you capture a Barbarian Outpost, receive a Tribal Village reward in addition to the usual [ICON_Gold] Gold. Pay half the usual cost to levy City-state units.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_LEADER_ADVENTURES_ENKIDU_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>Military Units receive bonus [ICON_STRENGTH] Combat Strength equal to the level of your most advanced Alliance (maximum 3).[NEWLINE][NEWLINE]When at war with a common foe, they and their allies share pillage rewards and combat experience gains if within 5 tiles. Their Alliances gain Alliance Points for being at war with a common foe.[NEWLINE][NEWLINE]When you capture a Barbarian Outpost, receive a Tribal Village reward in addition to the usual [ICON_Gold] Gold. Pay half the usual cost to levy City-state units.</Text>
+			<Text>Starts game with War-cart instead of Warrior unit.[NEWLINE][NEWLINE]Military Units receive bonus [ICON_STRENGTH] Combat Strength equal to the level of your most advanced Alliance (maximum 3).[NEWLINE][NEWLINE]When at war with a common foe, they and their allies share pillage rewards and combat experience gains if within 5 tiles. Their Alliances gain Alliance Points for being at war with a common foe.[NEWLINE][NEWLINE]When you capture a Barbarian Outpost, receive a Tribal Village reward in addition to the usual [ICON_Gold] Gold. Pay half the usual cost to levy City-state units.</Text>
 		</Replace>
 		<Row Tag="LOC_BBG_SUMMER_COMBAT_ALLY_1" Language="en_US">
 			<Text>+1 [ICON_STRENGTH] Combat Strength for Alliance level (Shūtur eli sharrī)</Text>
@@ -1144,7 +1148,7 @@
 			<Text>{LOC_GOVERNOR_THE_EDUCATOR_NAME} is focused on the cultivation of [ICON_SCIENCE] Scientific endeavors in the city. He is also quite skilled in the attraction of [ICON_GreatPerson] Great People to his city.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_EDUCATOR_GRANTS_DESCRIPTION" Language="en_US">
-			<Text>+100% [ICON_GreatPerson] Great People points generated per turn in the city by districts, buildings, pantheons and World Wonders.</Text>
+			<Text>+100% [ICON_GreatPerson] Great People points generated per turn in the city by districts, buildings, pantheons and world wonders.</Text>
 		</Replace>
 		
 		<!-- == Amani == -->
@@ -1253,10 +1257,10 @@
 			<Text>+1 Faith [ICON_Faith] from tiles with Charming or better Appeal.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_GODDESS_OF_THE_HUNT_DESCRIPTION" Language="en_US">
-			<Text>+1 [ICON_Production] Production and +2 [ICON_GOLD] Gold from Camps.</Text>
+			<Text>+1 [ICON_FOOD] Food and +2 [ICON_GOLD] Gold from Camps.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_GODDESS_OF_THE_HUNT_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>+1 [ICON_Production] Production and +2 [ICON_GOLD] Gold from Camps.</Text>
+			<Text>+1 [ICON_FOOD] Food and +2 [ICON_GOLD] Gold from Camps.</Text>
 		</Replace>
 
 
@@ -1357,7 +1361,7 @@
 			<Text>Unlocks the Builder ability to construct Fisheries.[NEWLINE][NEWLINE]+1 [ICON_Food] Food, +1 additional [ICON_Food] Food if adjacent to a sea resource. Must be built on a coastal plot.</Text>
 		</Replace>
 		<Replace Tag="LOC_ROUTE_RAILROAD_DESCRIPTION" Language="en_US">
-			<Text>Can only be constructed by Military Engineers. Does not cost a charge, but does cost 2 [ICON_RESOURCE_IRON] Iron and 1 [ICON_RESOURCE_COAL] Coal.[NEWLINE][NEWLINE]Greatly improves [ICON_Movement] Movement speed of any unit moving from one Railroad tile to another. [ICON_TradeRoute] Trade Routes traveling over Railroads can multiply the [ICON_Gold] Gold they get from districts at their destination.</Text>
+			<Text>Can only be constructed by Military Engineers. Does not cost a charge, but does cost 2 [ICON_RESOURCE_IRON] Iron.[NEWLINE][NEWLINE]Greatly improves [ICON_Movement] Movement speed of any unit moving from one Railroad tile to another. [ICON_TradeRoute] Trade Routes traveling over Railroads can multiply the [ICON_Gold] Gold they get from districts at their destination.</Text>
 		</Replace>
 		
 
@@ -1382,7 +1386,7 @@
 			<Text>+3 [ICON_Favor] Diplomatic Favor per turn and +2 [ICON_InfluencePerTurn] Influence Points per turn. Leveraging City-states costs half [ICON_Gold] Gold. City-state units gain +4 [ICON_Strength] Combat Strength if you are the City-state's Suzerain (including Leveraged Units).[NEWLINE]Awards +1 [Icon_Governor] Governor Title and +2 [ICON_Envoy] Envoys.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_GOV_FAITH_DESCRIPTION" Language="en_US">
-			<Text>Grants the ability to buy land units with [ICON_Faith] Faith in all owned cities.[NEWLINE]Pillaging Improvements and Districts provides bonus [ICON_Faith] Faith.[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
+			<Text>Grants the ability to buy land units with [ICON_Faith] Faith in all founded cities.[NEWLINE]Pillaging Improvements and Districts provides bonus [ICON_Faith] Faith.[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_GOV_SPIES_DESCRIPTION" Language="en_US">
 			<Text>+50% [ICON_PRODUCTION] toward Spies. All Spy Operations have a higher chance of success.[NEWLINE]Awards +1 [Icon_Governor] Governor Title, +2 Spy capacity and Spy unit.</Text>
@@ -1532,6 +1536,9 @@
 		</Replace>
 		<Replace Tag="LOC_BUILDING_ORSZAGHAZ_DESCRIPTION" Language="en_US">
 			<Text>+1 [ICON_Favor] Diplomatic Favor per City-State you are the Suzerain of.[NEWLINE][NEWLINE]Must be built on a River.</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_KOTOKU_IN_DESCRIPTION" Language="en_US">
+			<Text>+20% [ICON_Faith] Faith in this city. Grants 4 Warrior Monks. Allows purchasing of Warrior Monks in this city.[NEWLINE][NEWLINE]Must be built adjacent to a Holy Site district with a Temple.</Text>
 		</Replace>
 		
 
@@ -1929,6 +1936,9 @@
 		</Replace>
 		<Replace Tag="LOC_WORLD_CONGRESS_BAN_TRADE_WITH_PLAYER_DESC" Language="en_US">
 			<Text>International [ICON_TradeRoute] Trade Routes sent to the chosen player or from the chosen player provide -4 [ICON_Gold] Gold (can be negative).</Text>
+		</Replace>
+		<Replace Tag="LOC_WORLD_CONGRESS_EMPOWER_RELIGION_DESC" Language="en_US">
+			<Text>+10 [ICON_Religion] Religious Strength for all religious units of this [ICON_Religion] Religion.</Text>
 		</Replace>
 
 


### PR DESCRIPTION
New lines for 5.1 patch:
- Ottoman UU (naval) - can enter Ocean tiles regardless of researched Technologies ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/7e67f02793d0761f17c24799bf434474e6977f4f));
- Ottoman Ibrahim unique governor R2 promotion - +1 movement within 10 tiles of city instead of useless grievances ability ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/9ebd85d2b0bf2ce45eb06de8fb6316ef8051cc85));
- Goddess of the Hunt pantheon - +2 gold instead of +1 food ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/f21b65e4099c200f91b0126939d552ce59bea118));
- Railroad - cost increased to 2 iron per tile ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/d2b185f18234928e8280f461685801af25aa5740));
- Intelligence Agency - +50% production to Spies, +2 capacity (instead of +1) and 1 free Spy unit (as was before) ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/622ff00b31f39fdb94faf0725be907b93bfe9cd2));
- Statue of Zeus World Wonder - +35% instead of +50% to anti-cavalry ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/f32da63353bf61b4b5c865d53778e25345914127));
- Agoge policy - recon (Classical and earlier) (link below);
- Feudal Contract policy - recon (Renaissance and earlier) (link below);
- Grande Armee policy - recon (Industrial and earlier) (link below);
- Military First policy - recon (all) ([links for 4 policies](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/7e1e63c5872e6e95152bf5959c036674c9393c7d));
- Kotoku-in world wonder - allows purchasing Monk in this city (with wonder) (see link below);
- World Religion congress resolution - +10 strength for religious units only, no Monks ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/862fdf8f94a317358a94e98cfd499b7ad923d183)).
>
Edited lines for 5.1 patch:
- Eleanor leader ability - works grant +1 instead of +2 ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/d714830c759bba3ccbb64eff697e42bb28f21782));
- Ethiopia UU - +1 movement if starts in Hills instead of ignoring them ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/481c2eb63c995fa437cb2a11bbea91415a8dea5c));
- Sumerian leader ability - start game with War-cart instead of Warrior unit ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/dc3fd3b2f8cba4688e3ad49caf97eda1889c66f1)).
>
Deleted lines for 5.1 patch:
- Ethiopia UI - reverted to base-game (faith from adjacent mountains) ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/a3e0e42a8bf3a640aa84830d8de4f399a95d5ec7));
- Rome UD - reverted to base-game (no culture per adjacent districts) ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/a492752eaca80690be0b481d7c6fa3dd553256ef)).
>
Commits without any text changes:
- Ottoman bias - T3 river ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/9a0b33c1b9a2e34fe9442aecd2cbbe1a4765be96));
- Sumerian UU - combat strength and cost decreased ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/e9f4e716347f09df3f6d6774d75063ca053e5755));
- Helicopter unit - to 5 movements from 6 ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/7f290f7b6e5f1286ea257cf9fa5579a600368f00));
- Swords, Rome UU, Persia UU - increased iron cost ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/e77270643c7836abc26a74e513d6aafaff7b9e9d));
- Gaul bias - T5 quarry resources ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/0a9294688da6d2913ec1114a9cf87acdaf130bad));
- Nubia bias - T2 plains ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/282cf9034471cbae270fbb871c8816e2a4bce27a));
- Australia UI - buffed at Industrialization (from Steam Power); this change doesn't require text because it says something like "grants additional Food and Production through Technology and Civic trees" ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/462b87266599551a3184342ab4d551b0509226a6));
- Monks base strength nerf, Free Inquiry dedication bug-fixes ([link](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/commit/fe74bd65aa1017dab370ef1441bf4aeca80644df)).
>
New other lines:
- Base ranged naval units - Range of these units (1, 2, 3, 4);
- Warrior Monk R2 Promotion - 250 Religious pressure within 6 tiles clarification;
- Victor T3 promotion - anti-air icon;
- Pingala L1 promotion - clarification what affect +100% GPP;
- Orszaghaz World Wonder (English fix) - clarification of Diplomatic favor, +1 is equal +100%.
- Medina quarter policy - district icon;
- Liberalism policy - district icon;
- New deal policy - district icon;
- Serfdom policy - charge icon;
- Public Works policy - charge icon;
- Logistics policy - movement icon;
- Integrated Attack Logistics policy - movement icon; 
- Public Transport (English fix) - yields clarification; 
- Gothic Architecture policy (English fix) - toward Renaissance and earlier; 
- Wisselbanken policy (English fix) - +0.25 points (not .25), re-wrote sentence; 
- Machiavellianism policy - turn icon;
- Containment policy - government icon;
- Hallyu policy - promotion icon;
- Non-stated Actors policy - promotion icon;
- Press Gangs policy (English fix) - forgotten "+" character;
- Cree UU - promotion icon.
>
Edited other lines:
- Australia leader ability - turn icon;
- France civilization ability (English fix) - moved number and tourism icon near each other;
- Macedon leader ability - turn icon;
- Ottoman UB - first constructed UB grants free Governor Title; it is old artifact from v4 that nobody wrote before;
- Scotland UI - grants +1 appeal to adjacent tiles; edited sentence;
- Spain UI - 8 tiles from current capital; added Science icon;
- Divine Spark pantheon - Great People icons;
- City Patron pantheon - district icons;
- God of War and Plunder pantheon - Great People icons;
- Warlord Throne - production for all cities;
- Foreign Ministry (English fix) - moved items between sentences;
- Trench Warfare policy - for "all" (forgotten word);
- Insulae policy - district icon;
- Rome leader ability - simpify description, just grants Monument building; reason - other cases are giga rare and useless, no one rush Monument for first 8 turns in my opinion; if you don't agree we can discuss it in channel and then change to something else;
- Spain civilization ability - Corps and Army icons for Fleets and Armadas;
- Spain UI - forgotten "current" word for XP2;
- Pingala L1 (English fix) - lower case;
- Grand Master Chapel - can purchase in founded cities, not just owned.