### PR TITLE
Monk Cleaned UP

### DIFF
--- a/BetterBalancedGame.modinfo
+++ b/BetterBalancedGame.modinfo
@@ -11,7 +11,7 @@
 		<Teaser>Mod to balance multiplayer game.</Teaser>
 		<Authors>github.com/CivilizationVIBetterBalancedGame</Authors>
 		<Version>5010</Version>
-		<SpecialThanks>coloo, abstr, priz, seed.of.apricot, Klas, fl0r3k, WhySoHate, wazabaza, Ignasiuz, MarsLife(puj), Apeul, keride, Vodairo, iElden, D. / Jack The Narrator, codenaugh</SpecialThanks>
+		<SpecialThanks>coloo, abstr, priz, seed.of.apricot, Klas, fl0r3k, WhySoHate, wazabaza, Ignasiuz, MarsLife(puj), Apeul, keride, Vodairo, FlashyFeeds, ZhenjaMax, iElden, D. / Jack The Narrator, codenaugh</SpecialThanks>
 		<CompatibleVersions>2.0</CompatibleVersions>
 	</Properties>
 	<!--
@@ -281,7 +281,7 @@
 			<LuaReplace>ui/replacements/worldrankings_bbg.lua</LuaReplace>
 			</Properties>
 		</ReplaceUIScript>
-
+		<!--
 		<ReplaceUIScript id="productionpanel_bbg">
 			<Criteria>BBGTS_ProductionPanel_BBG_Expansion2</Criteria>
 			<Properties>
@@ -290,7 +290,7 @@
 				<LuaReplace>ui/replacements/ProductionPanel_BBG.lua</LuaReplace>
 			</Properties>
 		</ReplaceUIScript>
-
+		-->
 		<UpdateDatabase id="bbg_preload_db_updated">
 			<Properties>
 				<LoadOrder>11611</LoadOrder>
@@ -737,7 +737,7 @@
 		<File>ui/replacements/worldrankings_bbg.lua</File>
 		<File>ui/replacements/endgamemenu_bbg.lua</File>
 		<File>ui/replacements/endgamemenu.xml</File>
-		<File>ui/replacements/ProductionPanel_BBG.lua</File>
+		<!--<File>ui/replacements/ProductionPanel_BBG.lua</File>-->
 		<File>UI/Replacements/TradeOverview_BBG.lua</File>
 		
 		<File>data/new_bbg_icons.xml</File>

--- a/sql/base.sql
+++ b/sql/base.sql
@@ -991,10 +991,10 @@ INSERT INTO TypeTags(Type, Tag) VALUES
 -- Monks: Rework
 --Changes the way monk binds. This way it is the same mechanism as other follower beliefs and not a one time exception by Firaxis
 --Necessary for Kotoku
-UPDATE Modifiers SET ModifierType = 'MODIFIER_ALL_PLAYERS_ATTACH_MODIFIER' WHERE ModifierId = 'ALLOW_WARRIOR_MONKS';
+UPDATE Modifiers SET ModifierType = 'MODIFIER_ALL_CITIES_ATTACH_MODIFIER', SubjectRequirementSetId = 'CITY_FOLLOWS_RELIGION_REQUIREMENTS' WHERE ModifierId = 'ALLOW_WARRIOR_MONKS';
 
-INSERT INTO Modifiers(ModifierId, ModifierType, SubjectRequirementSetId) VALUES
-	('BBG_PLAYER_ALLOW_MONKS_IN_CITY', 'MODIFIER_PLAYER_CITIES_ENABLE_UNIT_FAITH_PURCHASE' ,'CITY_FOLLOWS_RELIGION_REQUIREMENTS');
+INSERT INTO Modifiers(ModifierId, ModifierType) VALUES
+	('BBG_PLAYER_ALLOW_MONKS_IN_CITY', 'MODIFIER_CITY_ENABLE_UNIT_FAITH_PURCHASE');
 
 INSERT INTO ModifierArguments(ModifierId, Name, Value) VALUES
 	('BBG_PLAYER_ALLOW_MONKS_IN_CITY', 'Tag', 'CLASS_WARRIOR_MONK');
@@ -1046,7 +1046,7 @@ UPDATE Units SET CostProgressionModel = 'COST_PROGRESSION_GAME_PROGRESS' WHERE U
 UPDATE Units SET CostProgressionParam1 = '1000' WHERE UnitType = 'UNIT_WARRIOR_MONK';
 
 --Next line makes monk purchase with kotoku possible to be unlocked if kotoku has a correct modifier
-UPDATE Units SET PurchaseYield = NULL, MustPurchase = '0', EnabledByReligion ='0' WHERE UnitType = 'UNIT_WARRIOR_MONK';
+UPDATE Units SET PurchaseYield = NULL, MustPurchase = '1', EnabledByReligion ='0' WHERE UnitType = 'UNIT_WARRIOR_MONK';
 
 --Disables Monk +10 congress interraction. Allows Kotoku city to receive 4 monks and recruit monks, even if city doesn't have a religion
 UPDATE Units SET TrackReligion = '0' WHERE UnitType = 'UNIT_WARRIOR_MONK';
@@ -1054,6 +1054,8 @@ UPDATE Units SET TrackReligion = '0' WHERE UnitType = 'UNIT_WARRIOR_MONK';
 UPDATE ModifierArguments SET Value = '5' WHERE ModifierId = 'EXPLODING_PALMS_INCREASED_COMBAT_STRENGTH';
 --Nerf Tier 4 promo Cobra Strike +15 down to +7 to be more in line with other promos
 UPDATE ModifierArguments SET Value = '7' WHERE ModifierId = 'COBRA_STRIKE_INCREASED_COMBAT_STRENGTH';
+--Deleting Monk Spread from sql (doesn't work since disabling TrackReligion), adding Basil-like spread in Lua
+DELETE FROM UnitPromotionModifiers WHERE UnitPromotionType = 'PROMOTION_MONK_DISCIPLES';
 
 --Add Unique Ability Icon and description to Monk's Scaling Ability in Unit Preview
 --Modifiers Themself are added through civic tree as monk is not unique to a given player.

--- a/ui/replacements/ProductionPanel_BBG.lua
+++ b/ui/replacements/ProductionPanel_BBG.lua
@@ -7,7 +7,7 @@ include("ProductionPanel")
 --The OverrideResults function will be replacing my current two functions
 --boolean check if monk and check for dynamic district prereq for aqueduct/damm/river watermil
 
-local bMonkKotoku = true --Lua side, needed for enabling monk kotoku. 
+local bMonkKotoku = false --Lua side, needed for enabling monk kotoku. 
 --Sql side is split between base.sql change to monk as a unit and monks as religion, to allow for a different binding mechanism
 --Same mechanism as any other faith purchase units and any other follower religious belief
 --Sql side 2: change to kotoku itself. Located in xp1__rise_and_fall.sql


### PR DESCRIPTION
--UI override no longer needed. Monk Solution is pure sql. UI override decoupled from modinfo. Added special thanks to Flashy and Zhenja
--Note: Keep UI override file in case it is ever needed in the future for watermills (UI side). Game Script side needs to be written to make it clean.
--Monk belief cleaned up. The same binding mechanism as all the other follower beliefs.
--Removed via sql modifier from Monk Disciples.
--Added via lua spread if monk has 'DISCIPLES' promotion. Same logic as basil. Same effect as basil: 5 ring tile around the defeated unit position. Strength of spread = 5xStrength of Defeated Unit. Religion = Religion Founded by Player, no Religion founded by player spread Majority Religion. If no Majority Religion, no Spread 
--Detected minor bug in basil spread effect. Plot iterator starts with 1 instead of 0. Standard arguments 0 to 5 for full first ring circle around the pPlot in BBG function GetAdjacentTiles().
Starting with 1 means one of the first ring tiles around the unit is not getting scanned for the presence of a city, resulting in spread not being applied in one position.