### PR TITLE
another English text for v5.1.0 Beta

### DIFF
--- a/lang/english.xml
+++ b/lang/english.xml
@@ -130,7 +130,7 @@
 			<Text>Receive +2 [ICON_RELIGION] Religious Strength for each Holy City converted to your Religion.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_BYZANTIUM_DESCRIPTION" Language="en_US">
-			<Text>Units receive +2 [ICON_Strength] Combat Strength or [ICON_Religion] Religious Strength for each Holy City converted to Byzantium's Religion (including Byzantium's Holy City). Byzantium's Religion is spread to nearby cities when an enemy civilization or City-state unit is defeated. +1 [ICON_GreatProphet] Great Prophet point from cities with a Holy Site district.</Text>
+			<Text>Units receive +2 [ICON_Strength] Combat Strength or [ICON_Religion] Religious Strength for each Holy City converted to Byzantium's Religion (including Byzantium's Holy City). +1 [ICON_GreatProphet] Great Prophet point from cities with a Holy Site district.[NEWLINE][NEWLINE]When defeats a unit, spreads Byzantium's Religion pressure (based on melee [ICON_Strength] Combat Strength of the defeated unit) within 5 tiles.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_BYZANTINE_TAGMA_DESCRIPTION" Language="en_US">
@@ -334,6 +334,13 @@
 		</Replace>
 		<Replace Tag="LOC_ABILITY_ETHIOPIAN_OROMO_CAVALRY_DESCRIPTION" Language="en_US">
 			<Text>+1 [ICON_Movement] Movement if starts in Hills.[NEWLINE][ICON_Bullet] +4 [ICON_STRENGTH] Combat Strength when fighting in Hills.</Text>
+		</Replace>
+		<!-- = unique improvement = -->
+		<Replace Tag="LOC_IMPROVEMENT_ROCK_HEWN_CHURCH_DESCRIPTION" Language="en_US">
+			<Text>Unlocks the Builder ability to construct a Rock-Hewn Church, unique to Ethiopia.[NEWLINE][NEWLINE]+1 [ICON_Faith] Faith for every adjacent Montain and Hills tile, +1 Appeal to adjacent tiles. Provides [ICON_TOURISM] Tourism from [ICON_FAITH] Faith, after researching Flight. Can only be built on Hills not adjacent to another Rock-Hewn Church.</Text>
+		</Replace>
+		<Replace Tag="LOC_IMPROVEMENT_ROCK_HEWN_CHURCH_EXPANSION2_DESCRIPTION" Language="en_US">
+			<Text>Unlocks the Builder ability to construct a Rock-Hewn Church, unique to Ethiopia.[NEWLINE][NEWLINE]+1 [ICON_Faith] Faith for every adjacent Montain and Hills tile, +1 Appeal to adjacent tiles. Provides [ICON_TOURISM] Tourism from [ICON_FAITH] Faith, after researching Flight. Can only be pillaged (never destroyed) by natural disasters. Can only be built on Hills or Volcanic Soil not adjacent to another Rock-Hewn Church.</Text>
 		</Replace>
 
 		<!-- == FRANCE == -->
@@ -811,7 +818,7 @@
 		<!-- == ROME == -->
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_TRAJANS_COLUMN_DESCRIPTION" Language="en_US">
-			<Text>All cities start with Monument building after unlocking Code of Laws.</Text>
+			<Text>All founded cities get free Monument building after unlocking Code of Laws civic.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_ROMAN_LEGION_DESCRIPTION" Language="en_US"> <!-- charge icon -->
@@ -990,7 +997,7 @@
 			<Text>Lahore City-State unique unit with a unique Promotion tree. Purchasable with [ICON_Faith] Faith. +15 [ICON_Strength] Combat Strength when Barracks, Armory, and Military Academy buildings are first constructed. Receives bonuses from [ICON_GREATGENERAL] Great General from any era.</Text>
 		</Replace>
 		<Replace Tag="LOC_UNIT_TRADER_DESCRIPTION" Language="en_US"> <!-- embarkation tip -->
-			<Text>May make and maintain a single [ICON_TradeRoute] Trade Route. Automatically creates Roads as it travels. Can embark since Celestial Navigation technology is researched.</Text>
+			<Text>May make and maintain a single [ICON_TradeRoute] Trade Route. Automatically creates Roads as it travels. Can embark since Celestial Navigation or Shipbuilding technology is researched.</Text>
 		</Replace>
 		<Replace Tag="LOC_UNIT_QUADRIREME_DESCRIPTION" Language="en_US">
 			<Text>Classical era ranged naval unit with [ICON_Range] Range of 1. Can only operate on Coastal waters until Cartography is researched.</Text>
@@ -1054,7 +1061,10 @@
 			<Text>+7 [ICON_Ranged] Ranged Strength when attacking.</Text>
 		</Replace>
 		<Replace Tag="LOC_PROMOTION_MONK_DISCIPLES_DESCRIPTION" Language="en_US">
-			<Text>When defeats non-barbarian unit, spreads 250 Religious pressure within 6 tiles.</Text>
+			<Text>When defeats a unit, spreads Religious pressure within 5 tiles.</Text>
+		</Replace>
+		<Replace Tag="LOC_PROMOTION_GARRISON_DESCRIPTION" Language="en_US">
+			<Text>+10 [ICON_Strength] Combat Strength when occupying any district or Fort.</Text>
 		</Replace>
 
 
@@ -1395,7 +1405,7 @@
 			<Text>Builders and Military Engineers gain the ability to use all of their [ICON_Charges] charges to provide bonus [ICON_Production] Production to a District Project. Each [ICON_Charges] charge grants 2% of project [ICON_Production] Production. Once per city per turn.[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_SEAPORT_DESCRIPTION" Language="en_US">
-			<Text>+25% combat experience for all naval units trained in this city. Allows Fleets and Armadas to be trained directly. Fleet and Armada training costs reduced 25%. +2 [ICON_GOLD] Gold on all Coast tiles for this city.</Text>
+			<Text>+25% combat experience for all naval units trained in this city. Once required Civics are unlocked, allows [ICON_Corps] Fleets or [ICON_Army] Armadas to be trained directly and their costs reduced by 25%. +2 [ICON_GOLD] Gold on all Coast tiles for this city.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_ARMORY_DESCRIPTION" Language="en_US">
 			<Text>+25% combat experience for all land units trained in this city. +1 [ICON_RESOURCE_NITER] Niter per turn once discovered.</Text>
@@ -1538,7 +1548,10 @@
 			<Text>+1 [ICON_Favor] Diplomatic Favor per City-State you are the Suzerain of.[NEWLINE][NEWLINE]Must be built on a River.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_KOTOKU_IN_DESCRIPTION" Language="en_US">
-			<Text>+20% [ICON_Faith] Faith in this city. Grants 4 Warrior Monks. Allows purchasing of Warrior Monks in this city.[NEWLINE][NEWLINE]Must be built adjacent to a Holy Site district with a Temple.</Text>
+			<Text>+20% [ICON_Faith] Faith in this city. Grants 4 Warrior Monks. Allows purchasing of Warrior Monks in this city regardless of city's Religion.[NEWLINE][NEWLINE]Must be built adjacent to a Holy Site district with a Temple.</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_TAJ_MAHAL_DESCRIPTION" Language="en_US">
+			<Text>+1 [ICON_GLORY_GOLDEN_AGE] Era Score from Historic Moment earned after this wonder is complete if that Moment is usually worth 2 or more [ICON_GLORY_GOLDEN_AGE] Era Score.[NEWLINE][NEWLINE]Must be built next to a River.</Text>
 		</Replace>
 		
 
@@ -1601,22 +1614,22 @@
 			<Text>Your cities can now train Nihang units.[NEWLINE][NEWLINE]A unit with a unique Promotion tree. Purchasable with [ICON_Faith] Faith. +15 [ICON_Strength] Combat Strength when Barracks, Armory, and Military Academy buildings are first constructed. Receives bonuses from [ICON_GREATGENERAL] Great General from any era.</Text>
 		</Replace>
 		<Replace Tag="LOC_CIVILIZATION_ARMAGH_BONUS" Language="en_US">
-			<Text>Your Builders can now make Monastery improvements.[NEWLINE][NEWLINE]Monasteries provide +3 [ICON_Faith] Faith. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
+			<Text>Your Builders can now make Monastery improvements.[NEWLINE][NEWLINE]+3 [ICON_Faith] Faith. +1 [ICON_Faith] Faith from every 2 adjacent districts. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
 		</Replace>
 		<Replace Tag="LOC_LEADER_TRAIT_ARMAGH_DESCRIPTION" Language="en_US">
-			<Text>Your Builders can now make Monastery improvements.[NEWLINE][NEWLINE]Monasteries provide +3 [ICON_Faith] Faith. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
+			<Text>Your Builders can now make Monastery improvements.[NEWLINE][NEWLINE]+3 [ICON_Faith] Faith. +1 [ICON_Faith] Faith from every 2 adjacent districts. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
 		</Replace>
 		<Replace Tag="LOC_CIVILIZATION_ARMAGH_BONUS_XP2" Language="en_US">
-			<Text>Your Builders can now make Monastery improvements.[NEWLINE][NEWLINE]Monasteries provide +3 [ICON_Faith] Faith. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
+			<Text>Your Builders can now make Monastery improvements.[NEWLINE][NEWLINE]+3 [ICON_Faith] Faith. +1 [ICON_Faith] Faith from every 2 adjacent districts. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
 		</Replace>
 		<Replace Tag="LOC_LEADER_TRAIT_ARMAGH_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>Your Builders can now make Monastery improvements.[NEWLINE][NEWLINE]Monasteries provide +3 [ICON_Faith] Faith. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
+			<Text>Your Builders can now make Monastery improvements.[NEWLINE][NEWLINE]+3 [ICON_Faith] Faith. +1 [ICON_Faith] Faith from every 2 adjacent districts. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_MONASTERY_DESCRIPTION" Language="en_US">
-			<Text>Unlocks the Builder ability to construct a Monastery.[NEWLINE][NEWLINE]+3 [ICON_Faith] Faith. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
+			<Text>Unlocks the Builder ability to construct a Monastery.[NEWLINE][NEWLINE]+3 [ICON_Faith] Faith. +1 [ICON_Faith] Faith from every 2 adjacent districts. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_MONASTERY_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>Unlocks the Builder ability to construct a Monastery.[NEWLINE][NEWLINE]+3 [ICON_Faith] Faith. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
+			<Text>Unlocks the Builder ability to construct a Monastery.[NEWLINE][NEWLINE]+3 [ICON_Faith] Faith. +1 [ICON_Faith] Faith from every 2 adjacent districts. +15 HP healing for friendly religious unit on this tile that has not attacked this turn. Cannot be built next to another Monastery.</Text>
 		</Replace>
 
 

--- a/lang/english.xml
+++ b/lang/english.xml
@@ -732,6 +732,10 @@
 		</Replace>
 
 		<!-- == NUBIA == -->
+		<!-- = leader ability = --> <!-- production icon -->
+		<Replace Tag="LOC_TRAIT_LEADER_KANDAKE_OF_MEROE_DESCRIPTION" Language="en_US">
+			<Text>+20% [ICON_Production] Production towards all districts rising to +40% [ICON_Production] Production if there is a Nubian Pyramid adjacent to the City Center.</Text>
+		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_PYRAMID_DESCRIPTION" Language="en_US">
 			<Text>Improvement that unlocks with Craftsmanship and must be built on Desert, Desert Hills, Floodplains, Plains, or Grassland. +1 [ICON_FOOD] Food and +2 [ICON_Faith] Faith.[NEWLINE][NEWLINE]Receives additional yields from adjacent districts:[NEWLINE]+2 [ICON_Food] Food for the City Center,[NEWLINE]+2 [ICON_SCIENCE] Science per adjacent Campus,[NEWLINE]+2 [ICON_PRODUCTION] Production per adjacent Industrial Zone,[NEWLINE]+2 [ICON_CULTURE] Culture per adjacent Theater Square,[NEWLINE]+2 [ICON_FAITH] Faith per adjacent Holy Site,[NEWLINE]+2 [ICON_GOLD] Gold per adjacent Commercial Hub and Harbor.[NEWLINE][NEWLINE]Can't be build next to another pyramid.</Text>


### PR DESCRIPTION
New lines:
- Ethiopia UI - remove base +1 faith from base-game description; it was my fault to delete UI description, I'm sorry about this;
- Nubia leader ability - production icon;
- Ranged R1 promotion - clarification: any district, Fort;
- Taj-Mahal World wonder - golden age icons.
>
Edited lines:
- Byzantium civ ability - 5 radius spread, based on strength of defeated unit;
- Rome leader ability - clarification: founded cities, free buidling;
- Trader unit - Shipbuilding technology too;
- Warrioir Monk R2 promotion - spread radius, spread strength;
- Seaport building - corps and armies icons;
- Kotoku-in - clarification: regardless of city religion;
- Monastery building - +1 faith from every 2 adjacent districts.
>
[Database.log](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/files/9792654/Database.log)
