### PR TITLE
5.1.8 English text

### DIFF
--- a/lang/april_fool.xml
+++ b/lang/april_fool.xml
@@ -5,9 +5,6 @@
         <Replace Tag="LOC_TRAIT_CIVILIZATION_BABYLON_DESCRIPTION" Language="zh_Hans_CN">
 			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspiration provide 100% of the [ICON_SCIENCE] Science and [ICON_CULTURE] Culture for technologies. Start the game with -50% [ICON_SCIENCE] Science and [ICON_CULTURE] Culture per turn.</Text>
 		</Replace>
-        <Replace Tag="LOC_TRAIT_CIVILIZATION_BABYLON_DESCRIPTION" Language="en_US">
-			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspiration provide 100% of the [ICON_SCIENCE] Science and [ICON_CULTURE] Culture for technologies. Start the game with -50% [ICON_SCIENCE] Science and [ICON_CULTURE] Culture per turn.</Text>
-		</Replace>
         <Replace Tag="LOC_TRAIT_CIVILIZATION_BABYLON_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspiration provide 100% of the [ICON_SCIENCE] Science and [ICON_CULTURE] Culture for technologies. Start the game with -50% [ICON_SCIENCE] Science and [ICON_CULTURE] Culture per turn.</Text>
 		</Replace>

--- a/lang/english.xml
+++ b/lang/english.xml
@@ -553,6 +553,13 @@
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_ADJACENT_DISTRICTS_DESCRIPTION" Language="en_US">
 			<Text>All [ICON_DISTRICT] districts receive an additional standard adjacency bonus for being adjacent to another [ICON_DISTRICT] district. Commercial Hubs do not receive bonuses from adjacent rivers.</Text>
 		</Replace>
+		<!-- = leader ability (Tokugawa) = -->
+		<Replace Tag="LOC_TRAIT_LEADER_TOKUGAWA_DESCRIPTION" Language="en_US">
+			<Text>International [ICON_TradeRoute] Trade Routes receive -25% Yield and [ICON_Tourism] Tourism, but Domestic [ICON_TradeRoute] Trade Routes provide +1 [ICON_Culture] Culture and +1 [ICON_Science] Science for every Specialty District at the Destination, and +2 [ICON_GOLD] Gold. Cities within 6 tiles of Japan's capital receive +4 [ICON_Amenities] Amenities and after researching Flight receive +1 [ICON_Tourism] Tourism for every District.</Text>
+		</Replace>
+		<Replace Tag="LOC_TRAIT_LEADER_TOKUGAWA_XP_DESCRIPTION" Language="en_US">
+			<Text>International [ICON_TradeRoute] Trade Routes receive -25% Yield and [ICON_Tourism] Tourism, but Domestic [ICON_TradeRoute] Trade Routes provide +1 [ICON_Culture] Culture and +1 [ICON_Science] Science for every Specialty District at the Destination, and +2 [ICON_GOLD] Gold. Cities within 6 tiles of Japan's capital are 100% loyal and after researching Flight receive +1 [ICON_Tourism] Tourism for every District.</Text>
+		</Replace>
 
 		<!-- == KHMER == -->
 		<!-- = civilization ability = -->
@@ -769,6 +776,11 @@
 		</Replace>
 
 		<!-- == OTTOMANS == -->
+		<!-- = leader ability (Suleiman Muhtesem, Magnificent) = -->
+		<Replace Tag="LOC_TRAIT_LEADER_SULEIMAN_ALT_DESCRIPTION" Language="en_US">
+			<Text>+10% [Icon_Science] Science and [Icon_CUlture] Culture when in a [ICON_GLORY_GOLDEN_AGE] Golden Age or [ICON_GLORY_SUPER_GOLDEN_AGE] Heroic Age. +4 [ICON_Strength] Combat Strength when not in a [ICON_GLORY_GOLDEN_AGE] Golden Age or [ICON_GLORY_SUPER_GOLDEN_AGE] Heroic Age against Civilizations who are also not in a [ICON_GLORY_GOLDEN_AGE] Golden Age or [ICON_GLORY_SUPER_GOLDEN_AGE] Heroic Age.</Text>
+		</Replace>
+
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_SULEIMAN_JANISSARY_DESCRIPTION" Language="en_US">
 			<Text>Ottoman unique Renaissance Era unit that replaces the Musketman. Starts with a [ICON_Promotion] free promotion. Stronger and cheaper than the Musketman. To train a Janissary a city must have a population of at least 2. If a city is founded by the Ottomans and trains a Janissary it loses a population.</Text>
@@ -790,7 +802,7 @@
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_SATRAPIES_DESCRIPTION" Language="en_US">
 			<Text>+1 [ICON_TradeRoute] Trade Route capacity with Political Philosophy civic. Receive +2 [ICON_Gold] Gold and +1 [ICON_Culture] Culture for routes between your own cities, additional +2 [ICON_Gold] Gold from Banking and Economic technologies, +2 [ICON_Culture] Culture from Medieval Faires and Urbanization civics. Roads built in your territory are one level more advanced than usual.</Text>
 		</Replace>
-		<!-- = leader ability = -->
+		<!-- = leader ability (Cyrus) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_FALL_BABYLON_DESCRIPTION" Language="en_US">
 			<Text>All units get +3 [ICON_Strength] Combat Strength when attacking. No penalties to yields in occupied cities. Declaring a Surprise War only counts as a Formal War for the purpose of warmongering and war weariness.</Text>
 		</Replace>
@@ -2356,32 +2368,41 @@
 		</Replace>
 
 
-
+		<!-- === APRIL FOOL 2022 GAMEMODE === -->
 		<Row Tag="BBG_GAMEMODE_BABYLON_NAME" Language="en_US">
 			<Text>April Fool 2022</Text>
 		</Row>
 		<Row Tag="BBG_GAMEMODE_BABYLON_DESCRIPTION" Language="en_US">
 			<Text>Discover a new experience of multiplayer. PERFECTLY Balanced and shorter.</Text>
 		</Row>
-		<!-- Beta -->
+		<Replace Tag="LOC_TRAIT_CIVILIZATION_BABYLON_DESCRIPTION" Language="en_US">
+			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspiration provide 100% of the [ICON_SCIENCE] Science and [ICON_CULTURE] Culture for technologies. Start the game with -50% [ICON_SCIENCE] Science and [ICON_CULTURE] Culture per turn.</Text>
+		</Replace>
+		
+
+
+		<!-- === BETA === -->
 		<Row Tag="LOC_BBG_FRONT_BETA_BAN_TRADE_TREATY_NAME" Language="en_US">
 			<Text>[COLOR_GREEN]Ban Trade Treaty Resolution[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="LOC_BBG_FRONT_BETA_BAN_TRADE_TREATY_DESC" Language="en_US">
 			<Text>Remove the Trade Treaty Resolution from World Congress.[NEWLINE](This Resolution is changed so disabled by default)</Text>
 		</Row>
-		<!--BBCC-->
+
+
+
+		<!-- === BETTER BALANCED CITY CENTERS (BBCC) === -->
 		<Row Tag="BBCC_SETTING_NAME" Language="en_US">
 			<Text>[COLOR:92,216,92]BCY: Affected City-Centers[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="BBCC_SETTING_DESC" Language="en_US">
-			<Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat city-center [ICON_Capital].[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills city-center [ICON_Capital].[NEWLINE]Consistent with Firaxis default formula.</Text>
+			<Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat City Center.[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills City Center.[NEWLINE]Consistent with Firaxis default formula.</Text>
 		</Row>
 		<Row Tag="BBCC_SETTING_YIELD_NAME" Language="en_US">
-			<Text>[COLOR:92,216,92]BCY: City-Center Yields[ENDCOLOR]</Text>
+			<Text>[COLOR:92,216,92]BCY: City Center Yields[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="BBCC_SETTING_YIELD_DESC" Language="en_US">
-			<Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat city-center [ICON_Capital].[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills city-center [ICON_Capital].[NEWLINE]Consistent with Firaxis default formula.</Text>
+			<Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat City Center.[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills City Center..[NEWLINE]Consistent with Firaxis default formula.</Text>
 		</Row>
 		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_M1_NAME" Language="en_US">
 			<Text>OFF</Text>
@@ -2405,19 +2426,19 @@
 			<Text>Standard</Text>
 		</Row>
 		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_0_DESC" Language="en_US">
-			<Text>Guaranteed Yields:[NEWLINE]Flat: 3[ICON_FOOD]1[ICON_PRODUCTION]0[ICON_GOLD]0[ICON_FAITH]0[ICON_CULTURE]0[ICON_SCIENCE][NEWLINE]Hills: 2[ICON_FOOD]2[ICON_PRODUCTION]0[ICON_GOLD]0[ICON_FAITH]0[ICON_CULTURE]0[ICON_SCIENCE][NEWLINE]City-Centers gain guaranteed yields, unless tile yield exceeds one of the guaranteed yields, due to presence or discovery of a resource. Excludes Russia, Mali and Canada from any BCY interractions.</Text>
+			<Text>City Centers gain guaranteed yields, unless tile yield exceeds one of the guaranteed yields, due to presence or discovery of a resource.[NEWLINE]Excludes Russia, Mali and Canada from any BCY interractions.</Text>
 		</Row>
 		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_1_NAME" Language="en_US">
-			<Text>NO RNG</Text>
+			<Text>No RNG</Text>
 		</Row>
 		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_1_DESC" Language="en_US">
-			<Text>Guaranteed Yields:[NEWLINE]Flat: 3[ICON_FOOD]1[ICON_PRODUCTION]0[ICON_GOLD]0[ICON_FAITH]0[ICON_CULTURE]0[ICON_SCIENCE][NEWLINE]Hills: 2[ICON_FOOD]2[ICON_PRODUCTION]0[ICON_GOLD]0[ICON_FAITH]0[ICON_CULTURE]0[ICON_SCIENCE][NEWLINE]City-Centers always have only guaranteed yields.</Text>
+			<Text>City Centers always have ONLY guaranteed yields.</Text>
 		</Row>
 		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_2_NAME" Language="en_US">
-			<Text>Legacy</Text>
+			<Text>Maximum</Text>
 		</Row>
 		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_2_DESC" Language="en_US">
-			<Text>Guaranteed Yields:[NEWLINE]Flat: 3[ICON_FOOD]1[ICON_PRODUCTION]0[ICON_GOLD]0[ICON_FAITH]0[ICON_CULTURE]0[ICON_SCIENCE][NEWLINE]Hills: 2[ICON_FOOD]2[ICON_PRODUCTION]0[ICON_GOLD]0[ICON_FAITH]0[ICON_CULTURE]0[ICON_SCIENCE][NEWLINE]City-Centers gain maximum between guaranteed yield and tile yield after removal of removable features.</Text>
+			<Text>City-Centers gain maximum between guaranteed yield and tile yield after removal of removable features.</Text>
 		</Row>
 	</LocalizedText>
 </GameData>

--- a/lang/english.xml
+++ b/lang/english.xml
@@ -2393,7 +2393,7 @@
 
 		<!-- === BETTER BALANCED CITY CENTERS (BBCC) === -->
 		<Row Tag="BBCC_SETTING_NAME" Language="en_US">
-			<Text>[COLOR:92,216,92]BCY: Affected City-Centers[ENDCOLOR]</Text>
+			<Text>[COLOR:92,216,92]BCY: affected City Centers[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="BBCC_SETTING_DESC" Language="en_US">
 			<Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat City Center.[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills City Center.[NEWLINE]Consistent with Firaxis default formula.</Text>
@@ -2402,7 +2402,7 @@
 			<Text>[COLOR:92,216,92]BCY: City Center Yields[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="BBCC_SETTING_YIELD_DESC" Language="en_US">
-			<Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat City Center.[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills City Center..[NEWLINE]Consistent with Firaxis default formula.</Text>
+			<Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat City Center.[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills City Center.[NEWLINE]Consistent with Firaxis default formula.</Text>
 		</Row>
 		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_M1_NAME" Language="en_US">
 			<Text>OFF</Text>
@@ -2426,19 +2426,19 @@
 			<Text>Standard</Text>
 		</Row>
 		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_0_DESC" Language="en_US">
-			<Text>City Centers gain guaranteed yields, unless tile yield exceeds one of the guaranteed yields, due to presence or discovery of a resource.[NEWLINE]Excludes Russia, Mali and Canada from any BCY interractions.</Text>
+			<Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat City Center.[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills City Center.[NEWLINE]City Centers gain guaranteed yields, unless tile yield exceeds one of the guaranteed yields, due to presence or discovery of a resource.[NEWLINE][NEWLINE]Excludes Russia, Mali and Canada from any BCY interractions.</Text>
 		</Row>
 		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_1_NAME" Language="en_US">
 			<Text>No RNG</Text>
 		</Row>
 		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_1_DESC" Language="en_US">
-			<Text>City Centers always have ONLY guaranteed yields.</Text>
+			<Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat City Center.[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills City Center.[NEWLINE]City Centers always have ONLY guaranteed yields.</Text>
 		</Row>
 		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_2_NAME" Language="en_US">
 			<Text>Maximum</Text>
 		</Row>
 		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_2_DESC" Language="en_US">
-			<Text>City-Centers gain maximum between guaranteed yield and tile yield after removal of removable features.</Text>
+			<Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat City Center.[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills City Center.[NEWLINE]City Centers gain maximum between guaranteed yield and tile yield after removal of removable features.</Text>
 		</Row>
 	</LocalizedText>
 </GameData>


### PR DESCRIPTION
New gameplay lines:
- Japan, Tokugawa leader ability - flat +2 Gold from internal trade route;
- Ottomans, Suleiman Magnificent leader ability - +10% bonus.

Moved lines:
- April Fool 2022 gamemode - leader ability line moved from `april_fool.xml` (this file will be removed soon) to language file.

Edited lines:
- BBCC/BCY - removed Capital icons, removed unnecessary icons, renamed "Legacy" to "Maximum".

Logs are OK.