### PR TITLE
5.2 English text (Beta build 4)

### DIFF
--- a/lang/english.xml
+++ b/lang/english.xml
@@ -185,20 +185,20 @@
 		<!-- == CHINA == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_DYNASTIC_CYCLE_DESCRIPTION" Language="en_US">
-			<Text>When completing a wonder receive a random [ICON_TechBoosted] Eureka and [ICON_CivicBoosted] Inspiration from the era of the wonder if available.[NEWLINE]Builder receive an additional [ICON_Charges] charge.</Text>
+			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspirations provide 60% of civics and technologies instead of 50%. When completing a wonder receive a random [ICON_TechBoosted] Eureka and [ICON_CivicBoosted] Inspiration from the era of the wonder if available.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_DYNASTIC_CYCLE_EXPANSION1_DESCRIPTION" Language="en_US">
-			<Text>When completing a wonder receive a random [ICON_TechBoosted] Eureka and [ICON_CivicBoosted] Inspiration from the era of the wonder if available.[NEWLINE]Builder receive an additional [ICON_Charges] charge.</Text>
+			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspirations provide 60% of civics and technologies instead of 50%. When completing a wonder receive a random [ICON_TechBoosted] Eureka and [ICON_CivicBoosted] Inspiration from the era of the wonder if available.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_DYNASTIC_CYCLE_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>When completing a wonder receive a random [ICON_TechBoosted] Eureka and [ICON_CivicBoosted] Inspiration from the era of the wonder if available.[NEWLINE]Builder receive an additional [ICON_Charges] charge.</Text>
+			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspirations provide 50% of civics and technologies instead of 40%. When completing a wonder receive a random [ICON_TechBoosted] Eureka and [ICON_CivicBoosted] Inspiration from the era of the wonder if available.</Text>
 		</Replace>
-		<!-- = leader ability = -->
+		<!-- = leader ability (Qin Shi Huang, Mandate of Heaven) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_FIRST_EMPEROR_DESCRIPTION" Language="en_US">
-			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspirations provide 60% of civics and technologies instead of 50%. When building Ancient and Classical wonders you may spend Builder [ICON_Charges] charge to complete 15% of the original wonder cost.</Text>
+			<Text>When building Ancient and Classical wonders you may spend Builder [ICON_Charges] charge to complete 15% of the original wonder cost. Builder receive an additional [ICON_Charges] charge.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_LEADER_FIRST_EMPEROR_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspirations provide 50% of civics and technologies instead of 40%. When building Ancient and Classical wonders you may spend Builder [ICON_Charges] charge to complete 15% of the original wonder cost. Canals are unlocked with the Masonry technology.</Text>
+			<Text>When building Ancient and Classical wonders you may spend Builder [ICON_Charges] charge to complete 15% of the original wonder cost. Builder receive an additional [ICON_Charges] charge. Canals are unlocked with the Masonry technology.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_CHINESE_CROUCHING_TIGER_DESCRIPTION" Language="en_US">
@@ -846,16 +846,19 @@
 			<Text>+{1_Value} when attacking (Cyrus)</Text>
 		</Replace>
 		<!-- = leader ability (Nader Shah) = -->
-		<Replace Tag="LOC_TRAIT_LEADER_NADER_SHAH_DESCRIPTION" Language="en_US">
-			<Text>+5 [ICON_Strength] Combat Strength when attacking district defenses or full Health Units. Receive +3 [Icon_Faith] Faith and +3 [Icon_Gold] Gold on domestic [ICON_TradeRoute] Trade Routes.</Text>
+		<!-- <Replace Tag="LOC_TRAIT_LEADER_NADER_SHAH_DESCRIPTION" Language="en_US">
+			<Text>+5 [ICON_Strength] Combat Strength when attacking full Health Units. Receive +3 [Icon_Faith] Faith and +3 [Icon_Gold] Gold on domestic [ICON_TradeRoute] Trade Routes.</Text>
 		</Replace>
-		<Replace Tag="LOC_ABILITY_NADER_SHAH_COMBAT_DESCRIPTION" Language="en_US">
+		-->
+		<!-- <Replace Tag="LOC_ABILITY_NADER_SHAH_COMBAT_DESCRIPTION" Language="en_US">
 			<Text>+5 [ICON_Strength] Combat Strength when attacking district defenses or full Health units (Nader Shah)</Text>
 		</Replace>
+		-->
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_PAIRIDAEZA_DESCRIPTION" Language="en_US">
 			<Text>The Early Empire civic unlocks the Builder ability to construct a Pairidaeza, unique to Persia.[NEWLINE][NEWLINE]+1 [ICON_CULTURE] Culture, +2 [ICON_GOLD] Gold, and +1 Appeal to adjacent tiles.[NEWLINE][NEWLINE]+1 [ICON_CULTURE] Culture for each adjacent Holy Site, Campus, and Theater Square. +1 [ICON_GOLD] Gold for each adjacent Commercial Hub, Harbor, Industrial Zone, and City Center. Additional +1 [ICON_CULTURE] Culture with the Diplomatic Service civic. Provides [ICON_TOURISM] Tourism after researching Flight.[NEWLINE][NEWLINE]Cannot be built on Snow tiles, Tundra tiles or Floodplains. Cannot be build next to another Pairidaeza.</Text>
 		</Replace>
+		
 
 		<!-- == PHOENICIA == -->
 		<!-- = leader ability = -->
@@ -901,9 +904,8 @@
 			<Text>All founded cities get free Monument building after unlocking the Code of Laws civic.</Text>
 		</Replace>
 		<!-- = leader ability (Julius Caesar) = -->
-		<!-- WIP BBG v5.2 Beta build 1 - free melee unit except [ICON_CAPITAL] Capital -->
 		<Replace Tag="LOC_TRAIT_LEADER_CAESAR_DESCRIPTION" Language="en_US">
-			<Text>+200 [ICON_Gold] Gold when you conquer a city for the first time, +100 [ICON_GOLD] Gold when you capture a [ICON_BARBARIAN] Barbarian Outpost, increasing to +500 [ICON_Gold] Gold for both with Steel technology (on Standard speed).[NEWLINE][NEWLINE]Receive a free melee unit each time you found a city. Gains an extra Wildcard Policy slot when capturing and retaining at least one city founded by a major civilization and owned by a major civilization at the time of capture (maximum 1 extra wildcard slot)</Text>
+			<Text>+200 [ICON_Gold] Gold when you conquer a city for the first time, +100 [ICON_GOLD] Gold when you capture a [ICON_BARBARIAN] Barbarian Outpost, increasing to +500 [ICON_Gold] Gold for both with Steel technology (on Standard speed).[NEWLINE][NEWLINE]Receive a free melee unit each time you found a non-capital city. Gains an extra Wildcard Policy slot when capturing and retaining at least one city founded by a major civilization and owned by a major civilization at the time of capture (maximum 1 extra wildcard slot)</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_ROMAN_LEGION_DESCRIPTION" Language="en_US"> <!-- charge icon -->
@@ -1486,10 +1488,10 @@
 			<Text>Allows construction of Cathedrals (+3 [ICON_Faith] Faith, 1 slot for Great Work of any type).</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_MOSQUE_DESCRIPTION" Language="en_US">
-			<Text>Allows construction of Mosques (+3 [ICON_Faith] Faith, grants 1 free Missionary of that city's majority Religion when constructed, Missionaries and Apostles +1 spread).</Text>
+			<Text>Allows construction of Mosques (+3 [ICON_Faith] Faith, grants 1 free Missionary of that city's majority Religion when constructed, Missionaries and Apostles created here have +2 spreads).</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_MOSQUE_DESCRIPTION" Language="en_US">
-			<Text>Grants 1 free Missionary of that city's majority Religion when constructed. Missionary and Apostles created here have +1 spread.</Text>
+			<Text>Grants 1 free Missionary of that city's majority Religion when constructed. Missionary and Apostles created here have +2 spreads.</Text>
 		</Replace>
 
 
@@ -1668,7 +1670,7 @@
 			<Text>Two tile impassable natural wonder. It appears as a Mountain. Doubles the terrain yields of all adjacent tiles.</Text>
 		</Replace>
 		<Replace Tag="LOC_FEATURE_ZHANGYE_DANXIA_DESCRIPTION" Language="en_US">
-			<Text>Three tile impassable natural wonder. It appears as a Mountain. Provides 2 [ICON_GREATGENERAL] Great General points and 2 [ICON_GREATMERCHANT] Great Merchant points if you own at least one of these tiles.</Text>
+			<Text>Three tile impassable natural wonder. It appears as a Mountain and provides 2 [ICON_GREATGENERAL] Great General points and 2 [ICON_GREATMERCHANT] Great Merchant points if you own at least one of these tiles.</Text>
 		</Replace>
 		<Replace Tag="LOC_FEATURE_FOUNTAIN_OF_YOUTH_DESCRIPTION" Language="en_US">
 			<Text>One tile natural wonder. It appears as an Oasis and provides +4 [ICON_Science] Science and +4 [ICON_Faith] Faith. Land combat units that enter it receive the ability 'Water of Life' (+10 HP healing in any territory).</Text>
@@ -1682,6 +1684,9 @@
 		<Row Tag="LOC_BBG_LYSEFJORD_GRANT_MOVEMENT_ABILITY_DESC" Language="en_US">
 			<Text>Njord's Blessing: +2 [ICON_Movement] Movement</Text>
 		</Row>
+		<Replace Tag="LOC_FEATURE_YOSEMITE_DESCRIPTION" Language="en_US">
+			<Text>Two tile impassable natural wonder. It appears as a Mountain and provides +1 [ICON_Gold] Gold and +1 [ICON_Science] Science to adjacent tiles.</Text>
+		</Replace>
 
 
 
@@ -2531,16 +2536,6 @@
 		</Replace>
 
 
-		<!-- === APRIL FOOL 2022 GAMEMODE === -->
-		<Row Tag="BBG_GAMEMODE_BABYLON_NAME" Language="en_US">
-			<Text>April Fool 2022</Text>
-		</Row>
-		<Row Tag="BBG_GAMEMODE_BABYLON_DESCRIPTION" Language="en_US">
-			<Text>Discover a new experience of multiplayer. PERFECTLY Balanced and shorter.</Text>
-		</Row>
-		<Replace Tag="LOC_TRAIT_CIVILIZATION_BABYLON_DESCRIPTION" Language="en_US">
-			<Text>[ICON_TechBoosted] Eurekas and [ICON_CivicBoosted] Inspiration provide 100% of the [ICON_SCIENCE] Science and [ICON_CULTURE] Culture for technologies. Start the game with -50% [ICON_SCIENCE] Science and [ICON_CULTURE] Culture per turn.</Text>
-		</Replace>
 
 		<!-- Better Balanced City Centers (BBCC) -->
 		<Row Tag="BBCC_SETTING_NAME" Language="en_US">

--- a/lang/english.xml
+++ b/lang/english.xml
@@ -2542,7 +2542,7 @@
 			<Text>[COLOR:92,216,92]BCY: affected City Centers[ENDCOLOR]</Text>
 		</Row>
 		<Row Tag="BBCC_SETTING_DESC" Language="en_US">
-			<Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for City Centers on flat tiles.[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for City Centers on hill tiles.[NEWLINE]Consistent with Firaxis default formula.</Text>
+			<Text>Which City Centers should be affected?</Text>
 		</Row>
 		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_M1_NAME" Language="en_US">
 			<Text>OFF</Text>
@@ -2562,23 +2562,30 @@
 		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_1_DESC" Language="en_US">
 			<Text>Enabled only for [ICON_Capital] Capitals</Text>
 		</Row>
-        <Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_0_NAME" Language="en_US">
-            <Text>Standard</Text>
-        </Row>
-        <Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_0_DESC" Language="en_US">
-            <Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat City Center.[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills City Center.[NEWLINE]City Centers gain guaranteed yields, unless tile yield exceeds one of the guaranteed yields, due to presence or discovery of a resource.[NEWLINE][NEWLINE]Excludes Russia, Mali and Canada from any BCY interractions.</Text>
-        </Row>
-        <Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_1_NAME" Language="en_US">
-            <Text>No RNG</Text>
-        </Row>
-        <Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_1_DESC" Language="en_US">
-            <Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat City Center.[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills City Center.[NEWLINE]City Centers always have ONLY guaranteed yields.</Text>
-        </Row>
-        <Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_2_NAME" Language="en_US">
-            <Text>Maximum</Text>
-        </Row>
-        <Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_2_DESC" Language="en_US">
-            <Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat City Center.[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills City Center.[NEWLINE]City Centers gain maximum between guaranteed yield and tile yield after removal of removable features.</Text>
-        </Row>
+		
+		<Row Tag="BBCC_SETTING_YIELD_NAME" Language="en_US">
+			<Text>[COLOR:92,216,92]BCY: City Center yields[ENDCOLOR]</Text>
+		</Row>
+		<Row Tag="BBCC_SETTING_YIELD_DESC" Language="en_US">
+			<Text>How to calculate City Centers yields?</Text>
+		</Row>
+		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_0_NAME" Language="en_US">
+			<Text>Standard</Text>
+		</Row>
+		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_0_DESC" Language="en_US">
+			<Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat City Center.[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills City Center.[NEWLINE]City Centers gain guaranteed yields, unless tile yield exceeds one of the guaranteed yields, due to presence or discovery of a resource.[NEWLINE][NEWLINE]Excludes Russia, Mali and Canada from any BCY interractions.</Text>
+		</Row>
+		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_1_NAME" Language="en_US">
+			<Text>No RNG</Text>
+		</Row>
+		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_1_DESC" Language="en_US">
+			<Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat City Center.[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills City Center.[NEWLINE]City Centers always have ONLY guaranteed yields.</Text>
+		</Row>
+		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_2_NAME" Language="en_US">
+			<Text>Maximum</Text>
+		</Row>
+		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_YIELD_2_DESC" Language="en_US">
+			<Text>Guaranteed +3 [ICON_FOOD] +1 [ICON_PRODUCTION] for flat City Center.[NEWLINE]Guaranteed +2 [ICON_FOOD] +2 [ICON_PRODUCTION] for hills City Center.[NEWLINE]City Centers gain maximum between guaranteed yield and tile yield after removal of removable features.</Text>
+		</Row>
 	</LocalizedText>
 </GameData>


### PR DESCRIPTION
New text lines:
- Yosemite - appears as Mountain.
>
Edited text lines:
- China civilization ability - boosts back from Qin Shi Huang (Mandate of Heaven), moved additional builder charge to Qin Shi Huang (Mandate of Heaven);
- China, Qin Shi Huang (Mandate of Heaven) leader ability - moved boosts to China civilization ability; additional builder charge back from China civilization ability;
- Rome, Julius Caesar leader ability - no warrior when settle Capital;
- Mosque belief & worship building - +2 spread (instead of +1);
- Shangye Danxia - English text fix.
>
Deleted text lines:
- Persia, Nader Shah leader ability - reverted to base-game (because of Firaxis fix and BBG fix);
- April Fool 2022 gamemode lines - removed completely.