### PR TITLE
5.2 English text (Beta build 6)

### DIFF
--- a/lang/english.xml
+++ b/lang/english.xml
@@ -127,10 +127,10 @@
 			<Text>When each [ICON_DISTRICT] specialty district type except the Government Plaza is constructed for the first time, receive the lowest [ICON_PRODUCTION] Production cost building that can currently be constructed in that district.</Text>
 		</Replace>
 		<!-- = unique building = -->
-		<Replace Tag="LOC_BUILDING_PALGUM_DESCRIPTION" Language="en_US">
+		<!-- <Replace Tag="LOC_BUILDING_PALGUM_DESCRIPTION" Language="en_US">		REVERTED 5.2 Beta, build 6
 			<Text>A building unique to Babylon. +1 [ICON_HOUSING] Housing and +2 [ICON_PRODUCTION] Production. Freshwater improved tiles receive +1 [ICON_FOOD] Food. City must be adjacent to a River.</Text>
 		</Replace>
-
+		-->
 		<!-- == BRAZIL == -->
 		<!-- = unique district = -->
 		<Replace Tag="LOC_DISTRICT_STREET_CARNIVAL_EXPANSION2_DESCRIPTION" Language="en_US">
@@ -228,13 +228,12 @@
 
 		<!-- == COLOMBIA == -->
 		<!-- = civilization ability = -->
-		<!-- <Replace Tag="LOC_TRAIT_CIVILIZATION_EJERCITO_PATRIOTA_DESCRIPTION" Language="en_US"> 	REVERTED to base-game, v5.2 Beta build 1
-			<Text>All units have +1 Sight. Promoting a unit does not end that unit's turn.</Text>
+		<Replace Tag="LOC_TRAIT_CIVILIZATION_EJERCITO_PATRIOTA_DESCRIPTION" Language="en_US">
+			<Text>+1 [ICON_Movement] Movement for all military units. Promoting a unit does not end that unit's turn.</Text>
 		</Replace>
 		<Replace Tag="LOC_ABILITY_EJERCITO_PATRIOTA_EXTRA_MOVEMENT_DESCRIPTION" Language="en_US">
-			<Text>+1 Sight to all units (Ejército Patriota)</Text>
+			<Text>+1 Movement for all military units (Ejército Patriota)</Text>
 		</Replace>
-		-->
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_CAMPANA_ADMIRABLE_DESCRIPTION" Language="en_US">
 			<Text>Earn a Comandante General when entering a new era. May not recruit [ICON_GreatGeneral] Great Generals.</Text>
@@ -727,7 +726,7 @@
 		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_KUPES_VOYAGE_DESCRIPTION" Language="en_US">
-			<Text>Begin the game in an Ocean tile. +2 [ICON_SCIENCE] Science and +2 [ICON_CULTURE] Culture per turn before you settle your first city. Gains a free Builder when settling your first city. The Palace receives +3 [ICON_HOUSING] Housing and +1 [ICON_AMENITIES] Amenity.</Text>
+			<Text>Begin the game in an Ocean tile. +2 [ICON_SCIENCE] Science and +2 [ICON_CULTURE] Culture per turn before you settle your first city. Gains +1 [ICON_CITIZEN] Population when settling your first city. The Palace receives +3 [ICON_HOUSING] Housing and +1 [ICON_AMENITIES] Amenity.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_MAORI_TOA_DESCRIPTION" Language="en_US"> <!-- = charge icon = -->
@@ -1294,7 +1293,7 @@
 			<Text>+4 [ICON_Production] Production and +4 [ICON_POWER] Power provided by the city's Coal, Oil, or Nuclear Power Plant.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_RESOURCE_MANAGER_SURPLUS_LOGISTICS_DESCRIPTION" Language="en_US">
-			<Text>+20% [ICON_Food] Growth in the city. Your [ICON_TradeRoute] Trade Routes to Magnus' city provide +1 [ICON_Food] Food and +2 [ICON_PRODUCTION] Production to their starting city.</Text>
+			<Text>+20% [ICON_Food] Growth in the city. Your [ICON_TradeRoute] Trade Routes to Magnus' city provide +2 [ICON_Food] Food and +2 [ICON_PRODUCTION] Production to their starting city.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_RESOURCE_MANAGER_EXPEDITION_DESCRIPTION" Language="en_US">
 			<Text>Settlers trained in the city do not consume a [ICON_Citizen] Population and gain +1 [ICON_Movement] Movement.</Text>
@@ -1534,7 +1533,7 @@
 			<Text>+1 [ICON_Amenities] Amenity, +2 [ICON_FOOD] Food, and +3 [ICON_Housing] Housing in Cities with a [ICON_Governor] Governor. -2 Loyalty in Cities without a [ICON_Governor] Governor.[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_GOV_CONQUEST_DESCRIPTION" Language="en_US">
-			<Text>+25% [ICON_Production] Production towards all naval and land military units in all cities. Reduces the maintenance cost of units by 1 [ICON_GOLD] Gold. Increases Strategic Resources stockpiles by 15 (on Online speed).[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
+			<Text>+25% [ICON_Production] Production towards all naval and land military units in all cities. Reduces the maintenance cost of units by 1 [ICON_GOLD] Gold. Increases Strategic Resources stockpiles by 15 (on Online speed). Provides you with 2 of each strategic resource per turn that you have revealed.[NEWLINE]Awards +1 [Icon_Governor] Governor Title.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_GOV_CITYSTATES_DESCRIPTION" Language="en_US">
 			<Text>+2 [ICON_InfluencePerTurn] Influence Points per turn. Leveraging City-states costs half [ICON_Gold] Gold. City-state units gain +4 [ICON_Strength] Combat Strength if you are the City-state's Suzerain (including Leveraged Units).[NEWLINE]Awards +1 [Icon_Governor] Governor Title and +2 [ICON_Envoy] Envoys.</Text>
@@ -1585,7 +1584,7 @@
 
 
 		<!-- === DISTRICTS === -->
-		<!-- WIP BBG v5.2 Beta build 1
+		<!-- WIP BBG v5.2 Beta build 1, NOT IMPLEMENTED
 		<Replace Tag="LOC_DISTRICT_CANAL_DESCRIPTION" Language="en_US">
 			<Text>A district to connect two bodies of water or a body of water to a City Center. [ICON_TradeRoute] Trade Routes traveling through it can multiply the [ICON_Gold] Gold they get from districts at their destination. Military Engineers can spend a [ICON_Charges] charge to complete 20% of a Canal's cost.[NEWLINE][NEWLINE]Must be built on flat tile that have a full land tile on each side of the waterway they create. Can be built on hill tile with the Steam Power technology. Canals may either go straight through the hex or bend by 60 degrees. Three-way Canal junctures are not allowed.</Text>
 		</Replace>
@@ -1597,11 +1596,6 @@
 
 
 		<!-- === NATURAL WONDERS === -->
-		<!-- WIP BBG v5.2 Beta build 1
-		<Replace Tag="LOC_FEATURE_BERMUDA_TRIANGLE_DESCRIPTION" Language="en_US">
-			<Text>Three tile natural wonder. All units that enter it are teleported to an ocean far away, lose 20 HP, and lose all remaining [ICON_Movement] Movement points. Naval units that do so earn the ability 'Mysterious Currents' (+1 [ICON_Movement] Movement).</Text>
-		</Replace>
-		-->
 		<Replace Tag="LOC_FEATURE_PAITITI_DESCRIPTION" Language="en_US">
 			<Text>Three tile impassable natural wonder. Provides +1 [ICON_Gold] Gold and +1 [ICON_Culture] Culture to adjacent tiles. Trade routes sent from cities that own at least one tile of Paititi generate +4 [ICON_Gold] Gold.</Text>
 		</Replace>
@@ -1776,9 +1770,8 @@
 		<Replace Tag="LOC_BUILDING_TORRE_DE_BELEM_DESCRIPTION" Language="en_US">
 			<Text>International [ICON_TradeRoute] Trade Routes receive +2 [ICON_GOLD] Gold for every Luxury Resource at the destination. When the Torre de Belém is constructed, all your cities receive the lowest [ICON_PRODUCTION] Production cost City Center building they can currently construct.[NEWLINE][NEWLINE]Must be built on a Coast tile that is adjacent to a Harbor district.</Text>
 		</Replace>
-		<!-- WIP BBG v5.2 Beta build 1 - This Wonder become automatically themed when it has all its slots filled. -->
 		<Replace Tag="LOC_BUILDING_HERMITAGE_DESCRIPTION" Language="en_US">
-			<Text>Must be built along a River.</Text>
+			<Text>This Wonder become automatically themed when it has all its slots filled.[NEWLINE][NEWLINE]Must be built along a River.</Text>
 		</Replace>
 
 
@@ -2114,7 +2107,7 @@
 			<Text>+5 [ICON_Strength] Combat Strength when in your territory (Finest Hour)</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVT_INHERENT_BONUS_COMMUNISM_XP1" Language="en_US">
-			<Text>+1 [ICON_Production] Production per [ICON_Citizen] Citizen in cities with [ICON_Governor] Governors.</Text>
+			<Text>+1 [ICON_Production] Production per [ICON_Citizen] Citizen in cities with [ICON_Governor] Governors. +1 yield to specialists of the respective district yield.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVT_INHERENT_BONUS_AUTOCRACY_ETHIOPIA" Language="en_US">
 			<Text>+1 to all yields for Palace, Government Plaza, Diplomatic Quarter and these districts' buildings.</Text>


### PR DESCRIPTION
New text lines:
- Gran Colombia civilization ability - +1 movement for all MILITARY units (base-game description says just for all units); same for ability tooltip.

Edited text lines:
- Maori leader ability - removed free builder, added free Citizen in 1st city;
- Magnus L1 promotion - reverted to +2 food;
- Government Plaza, Warlord Throne T1 building - additional +2 revealed strategic resources per turn;
  - this change was implemented for 1st Beta build but I forgot to write it;
- Hermitage world wonder - auto-themed when filled;
- Communism inherent bonus (legacy-able) - +1 yield to specialist of the respective district yield.

Deleted text lines:
- Babylon UD - reverted to base game (wrapped in comment).

Database.log & Localization.log are OK.