### PR TITLE
5.2.7 English text

### DIFF
--- a/lang/english.xml
+++ b/lang/english.xml
@@ -1599,8 +1599,12 @@
 
 
 		<!-- === NATURAL WONDERS === -->
+		<!-- TIP: XP2 tag used for World Wonders picker (in game lobby) for specified Wonders -->
+		<Replace Tag="LOC_FEATURE_BERMUDA_TRIANGLE_DESCRIPTION" Language="en_US">
+			<Text>Three tile natural wonder. Units that enter it are teleported to an ocean far away, but naval units that do so earn the ability 'Mysterious Currents' (+1 [ICON_Movement] Movement).</Text>
+		</Replace>
 		<Replace Tag="LOC_FEATURE_PAITITI_DESCRIPTION" Language="en_US">
-			<Text>Three tile impassable natural wonder. Provides +1 [ICON_Gold] Gold and +1 [ICON_Culture] Culture to adjacent tiles. Trade routes sent from cities that own at least one tile of Paititi generate +4 [ICON_Gold] Gold.</Text>
+			<Text>Three tile impassable natural wonder. Provides +1 [ICON_Gold] Gold and +1 [ICON_Culture] Culture to adjacent tiles. [ICON_TRADEROUTE] Trade routes sent from cities that own at least one tile of Paititi generate +4 [ICON_Gold] Gold.</Text>
 		</Replace>
 		<Replace Tag="LOC_FEATURE_GIANTS_CAUSEWAY_DESCRIPTION" Language="en_US">
 			<Text>Two tile impassable natural wonder. It provides +1 [ICON_CULTURE] Culture to adjacent tiles. Land combat units that enter adjacent tiles receive the ability 'Spear of Fionn' (+3 [ICON_STRENGTH] Combat Strength when attacking).</Text>
@@ -1623,8 +1627,14 @@
 		<Replace Tag="LOC_FEATURE_EYE_OF_THE_SAHARA_DESCRIPTION" Language="en_US">
 			<Text>Three tile natural wonder. Provides +2 [ICON_FOOD] Food, +2 [ICON_PRODUCTION] Production, and +2 [ICON_SCIENCE] Science.</Text>
 		</Replace>
+		<Replace Tag="LOC_FEATURE_EYE_OF_THE_SAHARA_XP2_DESCRIPTION" Language="en_US">
+			<Text>Three tile natural wonder. Provides +2 [ICON_FOOD] Food, +2 [ICON_PRODUCTION] Production, and +2 [ICON_SCIENCE] Science.</Text>
+		</Replace>
 		<Replace Tag="LOC_FEATURE_CLIFFS_DOVER_DESCRIPTION" Language="en_US">
-			<Text>Two tile natural wonder that can be found on coastal terrain. It appears as Cliffs and provides +2 [ICON_FOOD] Food, +3 [ICON_Culture] Culture, and +2 [ICON_Gold] Gold.</Text>
+			<Text>Two tile natural wonder that can be found on coastal terrain. It appears as Cliffs and provides +2 [ICON_FOOD] Food, +3 [ICON_Culture] Culture, and +3 [ICON_Gold] Gold. Provides +4 Appeal to adjacent tiles instead of the usual +2.</Text>
+		</Replace>
+		<Replace Tag="LOC_FEATURE_CLIFFS_DOVER_XP2_DESCRIPTION" Language="en_US">
+			<Text>Two tile natural wonder that can be found on coastal terrain. It appears as Cliffs and provides +2 [ICON_FOOD] Food, +3 [ICON_Culture] Culture, and +3 [ICON_Gold] Gold. Provides +4 Appeal to adjacent tiles instead of the usual +2.</Text>
 		</Replace>
 		<Replace Tag="LOC_FEATURE_CRATER_LAKE_DESCRIPTION" Language="en_US">
 			<Text>One tile natural wonder. It appears as a Lake and provides +2 [ICON_FOOD] Food, +2 [ICON_Science] Science, +5 [ICON_Faith] Faith.</Text>
@@ -1663,7 +1673,7 @@
 			<Text>Three tile impassable natural wonder. It appears as a Mountain and provides +3 [ICON_Faith] Faith to adjacent tiles. Religious units who move next to Mount Everest ignore Hills for the rest of the game.</Text>
 		</Replace>
 		<Replace Tag="LOC_FEATURE_TSINGY_DESCRIPTION" Language="en_US">
-			<Text>One tile impassable natural wonder. Provides +1 [ICON_FOOD] Food, +1 [ICON_Science] Science, and +1 [ICON_Culture] Culture. to adjacent tiles.</Text>
+			<Text>One tile impassable natural wonder. Provides +1 [ICON_FOOD] Food, +1 [ICON_Science] Science, and +1 [ICON_Culture] Culture to adjacent tiles.</Text>
 		</Replace>
 		<Replace Tag="LOC_FEATURE_KILIMANJARO_DESCRIPTION" Language="en_US">
 			<Text>One tile impassable natural wonder. It appears as a Mountain and provides +2 [ICON_Food] Food to adjacent tiles.</Text>
@@ -1690,7 +1700,19 @@
 			<Text>Njord's Blessing: +2 [ICON_Movement] Movement</Text>
 		</Row>
 		<Replace Tag="LOC_FEATURE_YOSEMITE_DESCRIPTION" Language="en_US">
-			<Text>Two tile impassable natural wonder. It appears as a Mountain and provides +1 [ICON_Gold] Gold and +1 [ICON_Science] Science to adjacent tiles.</Text>
+			<Text>Two tile impassable natural wonder. It appears as a Mountain and provides +1 [ICON_FOOD] Food, +1 [ICON_Gold] Gold and +1 [ICON_Science] Science to adjacent tiles.</Text>
+		</Replace>
+		<Replace Tag="LOC_FEATURE_YOSEMITE_XP2_DESCRIPTION" Language="en_US">
+			<Text>Two tile impassable natural wonder. It appears as a Mountain and provides +1 [ICON_FOOD] Food, +1 [ICON_Gold] Gold and +1 [ICON_Science] Science to adjacent tiles.</Text>
+		</Replace>
+		<Replace Tag="LOC_FEATURE_EYJAFJALLAJOKULL_DESCRIPTION" Language="en_US">
+			<Text>Two tile impassable natural wonder. It appears as a Volcano and provides +1 [ICON_Culture] Culture and +1 [ICON_Food] Food. On eruption it gives medium yields and is most likely to damage buildings and districts. Infrequently erupts, but is always active.</Text>
+		</Replace>
+		<Replace Tag="LOC_FEATURE_EYJAFJALLAJOKULL_XP2_DESCRIPTION" Language="en_US">
+			<Text>Two tile impassable natural wonder. It appears as a Volcano and provides +1 [ICON_Culture] Culture and +1 [ICON_Food] Food. On eruption it gives medium yields and is most likely to damage buildings and districts. Infrequently erupts, but is always active.</Text>
+		</Replace>
+		<Replace Tag="LOC_FEATURE_PAMUKKALE_DESCRIPTION" Language="en_US">
+			<Text>Two tile impassable natural wonder. It provides +1 [ICON_AMENITIES] Amenity to the cities that own at least one tile of Pamukkale. Major adjacency bonus to Theater Square, Campus, and Commercial Hub districts. Additional standard adjacency bonus to the Holy Site district. Entertainment Complex provides +1 [ICON_AMENITIES] Amenity if adjacent to the Pamukkale. It provides Fresh Water.</Text>
 		</Replace>
 
 

--- a/lang/english.xml
+++ b/lang/english.xml
@@ -1599,7 +1599,7 @@
 
 
 		<!-- === NATURAL WONDERS === -->
-		<!-- TIP: XP2 tag used for World Wonders picker (in game lobby) for specified Wonders -->
+		<!-- TIP: XP2 tag used for Natural Wonders picker (in game lobby) for specified Natural Wonders -->
 		<Replace Tag="LOC_FEATURE_BERMUDA_TRIANGLE_DESCRIPTION" Language="en_US">
 			<Text>Three tile natural wonder. Units that enter it are teleported to an ocean far away, but naval units that do so earn the ability 'Mysterious Currents' (+1 [ICON_Movement] Movement).</Text>
 		</Replace>


### PR DESCRIPTION
TIP: XP2 tag used for Natural Wonders picker (in game lobby) for specified Natural Wonders.

New text lines:
- Bermuda Triangle - revert description (I'M DUMB SORRY);
- Eye of the Sahara XP2;
- Cliffs of the Dover XP2;
- Yosemite XP2;
- Eyjafjallajokull - strange description, added and duplicated from XP2;
- Eyjafjallajokull XP2;
- Pamukkale - clarifying of the description (see text file).

Edited text lines:
- Paititi - Trade route icon;
- Cliffs of Dover - +3 gold (was +2 typo); it provides +4 appeal to adjacent tiles instead +2 (something like Uluru);
- Tsingy de Bemaraha - English fix, dot typo;
- Yosemite - it grants +1 Food (was missed).