### PR TITLE
5.3 English text

### DIFF
--- a/lang/english.xml
+++ b/lang/english.xml
@@ -361,7 +361,7 @@
 		</Replace>
 		<!-- = leader ability (Elizabeth) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_ELIZABETH_DESCRIPTION" Language="en_US">
-			<Text>+1 [ICON_TradeRoute] Trade Route capacity with Shipbuilding technology, Exploration civic and Mercantilism civic. [ICON_TradeRoute] Trade Routes to City-states provide +3 [ICON_GOLD] Gold for every [ICON_DISTRICT] specialty district in the origin city.[NEWLINE][NEWLINE]+100% [ICON_GOLD] Gold from Plundering [ICON_TradeRoute] Trade Routes with Naval Units. All Naval Raiders units gain +1 [ICON_Movement] Movement and +1 Sight.</Text>
+			<Text>+1 [ICON_TradeRoute] Trade Route capacity with Shipbuilding technology, Exploration civic and Mercantilism civic. [ICON_TradeRoute] Trade Routes to City-states provide +3 [ICON_GOLD] Gold for every [ICON_DISTRICT] specialty district in the origin city.[NEWLINE][NEWLINE]+100% [ICON_GOLD] Gold from Plundering [ICON_TradeRoute] Trade Routes with Naval Units. All Naval Raider units gain +1 [ICON_Movement] Movement and +1 Sight.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_ENGLISH_REDCOAT_DESCRIPTION" Language="en_US">
@@ -1621,6 +1621,12 @@
 		<Replace Tag="LOC_BBG_BUILDING_STOCK_EXCHANGE_DESCRIPTION" Language="en_US">
 			<Text>+4 [ICON_GOLD] Gold for each [ICON_TRADEROUTE] trade routes from this city.[NEWLINE]+2 [ICON_GOLD] Gold for each [ICON_TRADEROUTE] trade routes to this city.</Text>
 		</Replace>
+		<Replace Tag="LOC_BUILDING_SHRINE_DESCRIPTION" Language="en_US">
+			<Text>Allows the purchasing of Missionaries, and with the proper belief, Warrior Monks. These units can only be purchased with [ICON_Faith] Faith.</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_TEMPLE_DESCRIPTION" Language="en_US">
+			<Text>Allows the purchasing of Apostles, Gurus, Inquisitors. These units can only be purchased with [ICON_Faith] Faith.</Text>
+		</Replace>
 
 
 
@@ -1755,6 +1761,9 @@
 		<Replace Tag="LOC_FEATURE_PAMUKKALE_DESCRIPTION" Language="en_US">
 			<Text>Two tile impassable natural wonder. It provides +1 [ICON_AMENITIES] Amenity to the cities that own at least one tile of Pamukkale. Major adjacency bonus to Theater Square, Campus, and Commercial Hub districts. Additional standard adjacency bonus to the Holy Site district. Entertainment Complex provides +1 [ICON_AMENITIES] Amenity if adjacent to the Pamukkale. It provides Fresh Water.</Text>
 		</Replace>
+		<Row Tag="LOC_CAMPUS_MOUNTAIN_WONDER_ADJACENCY_BBG" Language="en_US">
+			<Text>+{1_num} [ICON_Science] Science from the adjacent mountain Natural wonder.</Text>
+		</Row>
 
 
 

--- a/lang/english.xml
+++ b/lang/english.xml
@@ -42,7 +42,7 @@
 		</Row>
 		<!-- = leader ability (Abraham Lincoln)= -->
 		<Replace Tag="LOC_TRAIT_LEADER_LINCOLN_DESCRIPTION" Language="en_US">
-			<Text>+100% Production [ICON_Production] toward Industrial Zones. Industrial Zones give +2 [ICON_Amenities] Amenities. Receive a free Melee unit after completing an Industrial Zone and their buildings. The free unit does not require resources when created or to maintain and receives +5 [ICON_Strength] Combat Strength.[NEWLINE][NEWLINE]Unit maintenance reduced by 1 [ICON_GOLD] Gold per turn, per unit.</Text>
+			<Text>+100% [ICON_PRODUCTION] Production to Industrial Zone and Aqueduct districts. Industrial Zones give +2 [ICON_Amenities] Amenities. Receive a free Melee unit after completing an Industrial Zone and their buildings. The free unit does not require resources when created or to maintain and receives +5 [ICON_Strength] Combat Strength.[NEWLINE][NEWLINE]Unit maintenance reduced by 1 [ICON_GOLD] Gold per turn, per unit.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_LEADER_LINCOLN_EXPANSION_DESCRIPTION" Language="en_US">
 			<Text>+100% [ICON_PRODUCTION] Production toward Industrial Zones. Industrial Zones give +2 [ICON_Amenities] Amenities and +3 Loyalty per turn. Plantations give -2 Loyalty per turn.[NEWLINE][NEWLINE]Receive a free Melee unit after completing an Industrial Zone and their buildings. The free unit does not require resources when created or to maintain and receives +5 [ICON_Strength] Combat Strength.[NEWLINE][NEWLINE]Unit maintenance reduced by 1 [ICON_GOLD] Gold per turn, per unit.</Text>
@@ -127,10 +127,9 @@
 			<Text>When each [ICON_DISTRICT] specialty district type except the Government Plaza is constructed for the first time, receive the lowest [ICON_PRODUCTION] Production cost building that can currently be constructed in that district.</Text>
 		</Replace>
 		<!-- = unique building = -->
-		<!-- <Replace Tag="LOC_BUILDING_PALGUM_DESCRIPTION" Language="en_US">		REVERTED 5.2 Beta, build 6
-			<Text>A building unique to Babylon. +1 [ICON_HOUSING] Housing and +2 [ICON_PRODUCTION] Production. Freshwater improved tiles receive +1 [ICON_FOOD] Food. City must be adjacent to a River.</Text>
+		<Replace Tag="LOC_BUILDING_PALGUM_DESCRIPTION" Language="en_US">
+			<Text>A building unique to Babylon. +1 [ICON_HOUSING] Housing and +2 [ICON_PRODUCTION] Production. Farms gain +1 [ICON_PRODUCTION] Production. Freshwater improved tiles except Farms receive +1 [ICON_FOOD] Food. City must be adjacent to a River.</Text>
 		</Replace>
-		-->
 		<!-- == BRAZIL == -->
 		<!-- = unique district = -->
 		<Replace Tag="LOC_DISTRICT_STREET_CARNIVAL_EXPANSION2_DESCRIPTION" Language="en_US">
@@ -154,7 +153,7 @@
 		</Replace>
 		<!-- = leader ability (Theodora) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_THEODORA_DESCRIPTION" Language="en_US">
-			<Text>Holy Sites and Hippodromes provide +1 [ICON_Culture] Culture bonus for each adjacent district.</Text>
+			<Text>Holy Sites and Hippodromes provide +1 [ICON_Culture] Culture for each adjacent district.</Text>
 		</Replace>
 		<Row Tag="LOC_BBG_THEODORA_HOLYSITE_CULTURE" Language="en_US">
 			<Text>+{1_num} [ICON_CULTURE] Culture from the adjacent {1_Num : plural 1?district; other?districts;}.</Text>
@@ -211,11 +210,9 @@
 			<Text>Builder receive an additional [ICON_Charges] charge. When building Ancient and Classical Wonders you may spend Builder [ICON_Charges] charge to complete 15% of the Wonder [ICON_PRODUCTION] Production cost. Canals are unlocked with the Masonry technology.</Text>
 		</Replace>
 		<!-- = leader ability (Qin Shi Huang, Unifier) = -->
-		<!-- 5.2.9 REVERTED
-			<Replace Tag="LOC_TRAIT_LEADER_QIN_ALT_DESCRIPTION" Language="en_US">
-			<Text>Melee units receive the Convert Barbarians action, but it removes the melee unit. All [ICON_GreatGeneral] Great Generals have an additional charge.</Text>
+		<Replace Tag="LOC_TRAIT_LEADER_QIN_ALT_DESCRIPTION" Language="en_US">
+			<Text>Melee units receive the Convert Barbarians action, but it removes the melee unit.[NEWLINE][NEWLINE]+50% [ICON_PRODUCTION] Production towards Encampment buildings. +1 [ICON_GreatWriter] Great Writer point from Encampment district. Barracks building provides 2 slots of [ICON_GreatWork_WRITING] Writing.</Text>
 		</Replace>
-		-->
 		<!-- = leader ability (Yongle) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_YONGLE_XP_DESCRIPTION" Language="en_US">
 			<Text>All Cities receive Projects where they can convert 50% of their [Icon_Production] Production into [Icon_Food] Food,  [Icon_Faith] Faith, or 100% if it is [Icon_GOLD] Gold.[NEWLINE][NEWLINE]Cities with 10 or more [ICON_CITIZEN] Population receive +1 [Icon_Gold] Gold, +0.5 [Icon_Science] Science, and +0.3 [Icon_Culture] Culture per turn for each [ICON_CITIZEN] Population in the city.</Text>
@@ -241,7 +238,7 @@
 		<!-- == COLOMBIA == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_EJERCITO_PATRIOTA_DESCRIPTION" Language="en_US">
-			<Text>+1 [ICON_Movement] Movement for all military units. Promoting a unit does not end that unit's turn.</Text>
+			<Text>+1 [ICON_Movement] Movement for all military units. Promoting Cavalry, Air units and Spies does not end these units' turn.</Text>
 		</Replace>
 		<Replace Tag="LOC_ABILITY_EJERCITO_PATRIOTA_EXTRA_MOVEMENT_DESCRIPTION" Language="en_US">
 			<Text>+1 Movement for all military units (Ejército Patriota)</Text>
@@ -260,11 +257,6 @@
 		<Replace Tag="LOC_ABILITY_LLANERO_ADJACENCY_STRENGTH_DESCRIPTION" Language="en_US">
 			<Text>+2 [ICON_Strength] Combat Strength from each adjacent Llanero unit.</Text>
 		</Replace>
-		<!-- = unique unit (Great Person - Comandante) = -->
-		<!-- <Replace Tag="LOC_GREATPERSON_COMANDANTE_STRENGTH_AOE_LAND" Language="en_US"> 	REVERTED to base-game, v5.2 Beta build 1
-			<Text>+5 [ICON_Strength] Combat Strength and +1 [ICON_Movement] Movement to all land military units within 2 tiles.</Text>
-		</Replace>
-		-->
 		<!-- = unique improvement = -->
 		<!-- WIP BBG v5.2 Beta build 1 - Can be built on Hill Plains and Hill Grassland next to a Plantation improvement. -->
 		<Replace Tag="LOC_IMPROVEMENT_HACIENDA_DESCRIPTION" Language="en_US">
@@ -278,8 +270,14 @@
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_CREE_OKIHTCITAW_DESCRIPTION" Language="en_US">
-			<Text>Cree unique Ancient era unit that replaces the Scout. Starts with a [ICON_Promotion] free promotion.</Text>
+			<Text>Cree unique Ancient era unit that replaces the Scout. Starts with a [ICON_Promotion] free promotion. +5 [ICON_STRENGTH] Combat Strength when fighting units with a higher base Combat Strength.</Text>
 		</Replace>
+		<Row Tag="LOC_BBG_ABILITY_OKIHTCITAW_STRONG_AGAINST_STRONGER_UNITS" Language="en_US">
+			<Text>+5 Combat Strength when fighting units with a higher base Combat Strength</Text>
+		</Row>
+		<Row Tag="LOC_BBG_ABILITY_OKIHTCITAW_STRONG_AGAINST_STRONGER_UNITS_DESCRIPTION" Language="en_US">
+			<Text>+5 [ICON_STRENGTH] Combat Strength when fighting units with a higher base Combat Strength.</Text>
+		</Row>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_MEKEWAP_DESCRIPTION" Language="en_US">
 			<Text>The Pottery technology unlocks the Builder ability to construct a Mekewap, unique to Cree.[NEWLINE][NEWLINE]+1 [ICON_PRODUCTION] Production and +1 [ICON_Housing] Housing.[NEWLINE][NEWLINE]Additional +1 [ICON_PRODUCTION] Production and +1 [ICON_Housing] Housing with the Civil Service civic. +1 [ICON_GOLD] Gold if adjacent to a Luxury resource, additional +2 [ICON_GOLD] Gold for every adjacent Luxury resource with the Cartography technology. +1 [ICON_FOOD] Food for every 2 adjacent Bonus Resources, increasing to +1 [ICON_FOOD] Food for every adjacent Bonus Resource with the Conservation civic.[NEWLINE][NEWLINE]Must be placed adjacent to a Bonus or Luxury resource. Cannot be built adjacent to another Mekewap.</Text>
@@ -288,11 +286,17 @@
 		<!-- == DUTCH == -->
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_RADIO_ORANJE_DESCRIPTION" Language="en_US">
-			<Text>Your [ICON_TradeRoute] Trade Routes to your own cities provide +2 Loyalty per turn for the starting city. [ICON_TradeRoute] Trade Routes to foreign cities or from foreign cities provide +2 [ICON_Culture] Culture to you and +1 [ICON_Culture] Culture for the sender.</Text>
+			<Text>Your [ICON_TradeRoute] Trade Routes to your own cities provide +2 Loyalty per turn for the starting city. [ICON_TradeRoute] Trade Routes to foreign cities or from foreign cities provide +2 [ICON_Culture] Culture to you and +1 [ICON_Culture] Culture for the sender. +3 [ICON_STRENGTH] Combat Strength for all Naval units when defending in Polder improvement.</Text>
 		</Replace>
+		<Row Tag="LOC_BBG_POLDER_DEFENSIVE_CS" Language="en_US">
+			<Text>+3 when defending in Polder (Radio Oranje)</Text>
+		</Row>
+		<Row Tag="LOC_BBG_POLDER_DEFENSIVE_CS_DESC" Language="en_US">
+			<Text>+3 [ICON_STRENGTH] Combat Strength when defending in Polder improvement.</Text>
+		</Row>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_POLDER_DESCRIPTION" Language="en_US">
-			<Text>The Guilds civic unlocks the Builder ability to construct a Polder, unique to Netherlands.[NEWLINE][NEWLINE]+1 [ICON_FOOD] Food, +1 [ICON_Production] Production, and +0.5 [ICON_Housing] Housing. Increases [ICON_Movement] Movement Cost of tile to 3.[NEWLINE][NEWLINE]+1 [ICON_FOOD] Food for every adjacent Polder, increasing to +2 [ICON_FOOD] Food for every adjacent Polder with the Replaceable Parts technology. +1 [ICON_PRODUCTION] Production for every adjacent Harbor. +1 [ICON_PRODUCTION] Production for every 2 adjacent Polders, increasing to +1 [ICON_PRODUCTION] Production for every adjacent Polder with the Replaceable Parts technology. +4 [ICON_GOLD] Gold with the Civil Engineering civic.[NEWLINE][NEWLINE]Must be placed on a Coast or Lake tile adjacent to 2 or more passable land tiles.</Text>
+			<Text>The Feudalism civic unlocks the Builder ability to construct a Polder, unique to Netherlands.[NEWLINE][NEWLINE]+1 [ICON_FOOD] Food, +1 [ICON_Production] Production, and +0.5 [ICON_Housing] Housing. Increases [ICON_Movement] Movement Cost of tile to 3.[NEWLINE][NEWLINE]+1 [ICON_FOOD] Food for every adjacent Polder, increasing to +2 [ICON_FOOD] Food for every adjacent Polder with the Replaceable Parts technology. +1 [ICON_PRODUCTION] Production for every adjacent Harbor. +1 [ICON_PRODUCTION] Production for every 2 adjacent Polders, increasing to +1 [ICON_PRODUCTION] Production for every adjacent Polder with the Replaceable Parts technology. +4 [ICON_GOLD] Gold with the Civil Engineering civic.[NEWLINE][NEWLINE]Must be placed on a Coast or Lake tile adjacent to 1 or more passable land tiles.</Text>
 		</Replace>
 
 		<!-- == EGYPT == -->
@@ -303,9 +307,17 @@
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_ITERU_EXPANSION2_DESCRIPTION" Language="en_US">
 			<Text>+25% [ICON_Production] Production towards [ICON_DISTRICT] districts and wonders if placed next to a River. Does not receive damage from Floods.</Text>
 		</Replace>
-		<!-- = leader ability = -->
+		<!-- = leader ability (Egypt, Cleopatra Egyptian) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_MEDITERRANEAN_EXPANSION2_DESCRIPTION" Language="en_US">
 			<Text>Your [ICON_TradeRoute] Trade Routes to other civilizations provide +6 [ICON_Gold] Gold for Egypt. Other civilizations' [ICON_TradeRoute] Trade Routes to Egypt provide +2 [ICON_Food] Food for them and +2 [ICON_Gold] Gold for Egypt. Trading with Allies earns twice as many bonus Alliance Points.</Text>
+		</Replace>
+		<!-- = leader ability (Ramses II) = -->
+		<Replace Tag="LOC_TRAIT_LEADER_RAMSES_DESCRIPTION" Language="en_US">
+			<Text>Gain [ICON_CULTURE] Culture equal to 10% of the construction cost when finishing Buildings and 25% when completing Wonders.</Text>
+		</Replace>
+		<!-- = leader ability (Egypt, Cleopatra Ptolemaic) = -->
+		<Replace Tag="LOC_TRAIT_LEADER_CLEOPATRA_ALT_DESCRIPTION" Language="en_US">
+			<Text>Resources on Floodplains under City Center district or with an improvement receive +1 [ICON_FOOD] Food and +1 [ICON_CULTURE] Culture. Owned Floodplains tiles grant +1 Appeal to adjacent tiles instead of usual -1.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_EGYPTIAN_CHARIOT_ARCHER_DESCRIPTION" Language="en_US">
@@ -346,6 +358,10 @@
 		<!-- = leader ability (Victoria - Age of Steam) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_VICTORIA_ALT_DESCRIPTION" Language="en_US">
 			<Text>+10% [ICON_PRODUCTION] Production in Cities for every Industrial Zone building in that city. +1 [ICON_PRODUCTION] Production to all Strategic Resources.</Text>
+		</Replace>
+		<!-- = leader ability (Elizabeth) = -->
+		<Replace Tag="LOC_TRAIT_LEADER_ELIZABETH_DESCRIPTION" Language="en_US">
+			<Text>+1 [ICON_TradeRoute] Trade Route capacity with Shipbuilding technology, Exploration civic and Mercantilism civic. [ICON_TradeRoute] Trade Routes to City-states provide +3 [ICON_GOLD] Gold for every [ICON_DISTRICT] specialty district in the origin city.[NEWLINE][NEWLINE]+100% [ICON_GOLD] Gold from Plundering [ICON_TradeRoute] Trade Routes with Naval Units. All Naval Raiders units gain +1 [ICON_Movement] Movement and +1 Sight.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_ENGLISH_REDCOAT_DESCRIPTION" Language="en_US">
@@ -424,7 +440,7 @@
 		<!-- == GAUL == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_GAUL_DESCRIPTION" Language="en_US">
-			<Text>Mines provide a minor adjacency bonus for all districts, a Culture Bomb of unowned territory, and receive +1 [ICON_CULTURE] Culture once Bronze working researched. Specialty districts do not receive a minor adjacency for being adjacent to another district and these districts cannot be built adjacent to the City Center.</Text>
+			<Text>Mines provide a minor adjacency bonus for all districts, receive +1 [ICON_CULTURE] Culture once Bronze Working technology is researched and grants a Culture Bomb of unowned territory once Iron Working technology is researched. Specialty districts do not receive a minor adjacency for being adjacent to another district and these districts cannot be built adjacent to the City Center.</Text>
 		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_AMBIORIX_DESCRIPTION" Language="en_US">
@@ -471,16 +487,16 @@
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_IMPERIAL_FREE_CITIES_DESCRIPTION" Language="en_US">
 			<Text>After unlocking the Guilds civic, each city can build one more [ICON_DISTRICT] district than usual (exceeding the normal limit based on [ICON_Citizen] Population).</Text>
 		</Replace>
-		<!-- = leader ability = -->
+		<!-- = leader ability (Frederick Barbarossa) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_HOLY_ROMAN_EMPEROR_DESCRIPTION" Language="en_US"> <!-- add icon -->
 			<Text>One extra Military policy slot in any [ICON_Government] government. +7 [ICON_Strength] Combat Strength when attacking city-states.</Text>
 		</Replace>
+		<!-- = leader ability (Ludwig II) = -->
+		<Replace Tag="LOC_TRAIT_LEADER_LUDWIG_DESCRIPTION" Language="en_US"> <!-- add icon -->
+			<Text>Finished Wonders receive +2 [ICON_CULTURE] Culture for every adjacent District as adjacency bonus. All [ICON_CULTURE] Culture adjacencies provide [ICON_TOURISM] Tourism after discovering Castles.</Text>
+		</Replace>
 
 		<!-- == GREECE == -->
-		<!-- = civilization ability = -->
-		<Replace Tag="LOC_TRAIT_CIVILIZATION_PLATOS_REPUBLIC_DESCRIPTION" Language="en_US">
-			<Text>One extra Wildcard policy slot in any [ICON_Government] government after discovering the Political Philosophy civic.</Text>
-		</Replace>
 		<!-- = leader ability (Gorgo) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_THERMOPYLAE_DESCRIPTION" Language="en_US">
 			<Text>Combat victories provide [ICON_Culture] Culture equal to 50% of the [ICON_Strength] Combat Strength of the defeated unit (on Online speed).[NEWLINE][NEWLINE]+1 [ICON_Strength] Combat Strength for each Military policy slot in your [ICON_Government] government.</Text>
@@ -540,7 +556,7 @@
 			<Text>Hungarian unique Industrial era unit that replaces Cavalry. +2 [ICON_Strength] Combat Strength from every City-state of which you are suzerain.</Text>
 		</Replace>
 		<Replace Tag="LOC_ABILITY_HUSZAR_DESCRIPTION" Language="en_US">
-			<Text>+2 [ICON_Strength] Combat Strength from every City-State of which you are suzerain.</Text>
+			<Text>+2 [ICON_Strength] Combat Strength from every City-state of which you are suzerain.</Text>
 		</Replace>
 		<Row Tag="LOC_ABILITY_HUSZAIR_COMBAT_PREVIEW" Language="en_US">	<!-- Change this word so it fits your language syntax and style! (for English UI tooltip now: +2 from Armagh) -->
 			<Text>from</Text>
@@ -554,7 +570,7 @@
 		<!-- == INDIA == -->
 		<!-- = leader ability (Chandragupta) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_ARTHASHASTRA_DESCRIPTION" Language="en_US">
-			<Text>Holy Site grants +1 [ICON_GreatGeneral] Great General point per turn. Shrine, Temple and Worship building grants +1 [ICON_Movement] Movement, +1 Sight and +2 [ICON_STRENGTH] Combat Strength respectively for all newly trained military units in the city.</Text>
+			<Text>Holy Site grants +1 [ICON_GreatGeneral] Great General point per turn. +1 [ICON_STRENGTH] Combat Strength for each building in Holy Site district for all newly trained military units in the city. Shrine and Temple building grants +1 [ICON_Movement] Movement and +1 Sight respectively for all newly trained military units in the city.[NEWLINE][NEWLINE]Once required Civics are unlocked, allows cities with Worship building train [ICON_Corps] Corps or [ICON_Army] Armies directly and their costs reduced by 25%.</Text>
 		</Replace>
 		<Row Tag="LOC_BBG_CHANDRA_MOVEMENT_ABILITY_DESC" Language="en_US">
 			<Text>+1 [ICON_Movement] Movement from Shrine building (Arthashastra)</Text>
@@ -617,7 +633,7 @@
 		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_MONASTERIES_KING_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>Holy Sites are granted a Major adjacency in [ICON_FAITH] Faith and [ICON_FOOD] Food with Rivers, and +2 [ICON_Housing] Housing if on a River.</Text>
+			<Text>Holy Sites are granted a major adjacency in [ICON_FAITH] Faith and [ICON_FOOD] Food from Rivers, +2 [ICON_Housing] Housing if built adjacent to a River, and trigger a Culture Bomb.</Text>
 		</Replace>
 		<Row Tag="LOC_DISTRICT_HOLY_SITE_RIVER_FAITH" Language="en_US">
 			<Text>+{1_num} [ICON_Faith] Faith from the river.</Text>
@@ -636,7 +652,7 @@
 		<!-- == KONGO == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_NKISI_DESCRIPTION" Language="en_US">
-			<Text>[ICON_GreatWork_Relic] Relics grant additional +2 [ICON_Food] Food, +2 [ICON_Production] Production, +4 [ICON_Gold] Gold and +1 [ICON_Faith] Faith. [ICON_GreatWork_Artifact] Artifacts and [ICON_GreatWork_Sculpture] Sculptures grant additional +2 [ICON_Food] Food, +2 [ICON_Production] Production, +4 [ICON_Gold] Gold and +4 [ICON_Faith] Faith. Palace has slots for 5 Great Works.[NEWLINE][NEWLINE]Receive 50% more [ICON_GreatWriter] Great Writer, [ICON_GreatArtist] Great Artist, [ICON_GreatMusician] Great Musician, and [ICON_GreatMerchant] Great Merchant points. +100% [ICON_PRODUCTION] Production to Archaeologists. </Text>
+			<Text>[ICON_GreatWork_Relic] Relics grant additional +2 [ICON_Food] Food, +2 [ICON_Production] Production, +4 [ICON_Gold] Gold and +1 [ICON_Faith] Faith. [ICON_GreatWork_Artifact] Artifacts and [ICON_GreatWork_Sculpture] Sculptures grant additional +2 [ICON_Food] Food, +2 [ICON_Production] Production, +4 [ICON_Gold] Gold and +4 [ICON_Faith] Faith. Palace has slots for 5 Great Works.[NEWLINE][NEWLINE]Receive 50% more [ICON_GreatWriter] Great Writer, [ICON_GreatArtist] Great Artist, [ICON_GreatMusician] Great Musician, and [ICON_GreatMerchant] Great Merchant points. +100% [ICON_PRODUCTION] Production to Archaeologists.</Text>
 		</Replace>
 		<!-- = leader ability (Mvemba a Nzinga) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_RELIGIOUS_CONVERT_DESCRIPTION" Language="en_US">
@@ -651,7 +667,7 @@
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_KONGO_SHIELD_BEARER_DESCRIPTION" Language="en_US">
-			<Text>Kongo unique Classical era unit that replaces the Swordsman. +1 [ICON_Movement] Movement, +10 [ICON_Strength] Combat Strength when defending against ranged attacks. Can see through Woods and Rainforests.</Text>
+			<Text>Kongo unique Classical era unit that replaces the Swordsman. +10 [ICON_Strength] Combat Strength when defending against ranged attacks. Can see through Woods and Rainforests.</Text>
 		</Replace>
 		<Replace Tag="LOC_ABILITY_NAGAO_DESCRIPTION" Language="en_US">
 			<Text>+10 [ICON_Strength] Combat Strength when defending against ranged units.[NEWLINE][ICON_Bullet] Can see through Woods and Rainforests.</Text>
@@ -722,7 +738,7 @@
 		<!-- == MALI == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_MALI_GOLD_DESERT_DESCRIPTION" Language="en_US">
-			<Text>City Centers gain +1 [ICON_FAITH] Faith and +1 [ICON_FOOD] Food for every adjacent Desert and Desert Hills tiles. -30% [ICON_PRODUCTION] Production toward constructing buildings or training units. -30% yields for harvesting a resource or removing a feature.[NEWLINE][NEWLINE]Mines receive -1 [ICON_PRODUCTION] Production and +1 [ICON_GOLD] Gold, additional +1 [ICON_GOLD] Gold with Currency, Banking and Economy technologies. May purchase Commercial Hub district buildings with [ICON_Faith] Faith.</Text>
+			<Text>City Centers gain +2 [ICON_FAITH] Faith if adjacent to Desert tile and +1 [ICON_FOOD] Food for every adjacent Desert tile. -30% [ICON_PRODUCTION] Production toward constructing buildings or training units.[NEWLINE][NEWLINE]Mines receive -1 [ICON_PRODUCTION] Production and +4 [ICON_GOLD] Gold. May purchase Commercial Hub district buildings with [ICON_Faith] Faith. -50% of the normal cost to purchase Desert tiles.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_MALI_MANDEKALU_CAVALRY_DESCRIPTION" Language="en_US">
@@ -733,6 +749,10 @@
 		</Replace>
 		<Replace Tag="LOC_ABILITY_MANDEKALU_PROTECT_TRADER_DESCRIPTION" Language="en_US">
 			<Text>This Mandekalu Cavalry protects nearby Trade units from being plundered on land tiles.[NEWLINE][ICON_Bullet] Gain [ICON_GOLD] Gold equal to 50% that unit's base [ICON_Strength] Combat Strength (on Online speed).</Text>
+		</Replace>
+		<!-- = unique district = -->
+		<Replace Tag="LOC_DISTRICT_SUGUBA_DESCRIPTION" Language="en_US">
+			<Text>A district unique to Mali specializing in finance and trade that replaces the Commercial Hub. Units, Buildings, and Districts are 5% cheaper to purchase with [ICON_GOLD] Gold and [ICON_FAITH] Faith in this City.[NEWLINE][NEWLINE]+2 [ICON_Gold] Gold bonus for each adjacent Holy Site. +2 [ICON_Gold] Gold bonus from a tile containing a River edge. +1 [ICON_Gold] Gold bonus for every two adjacent district tiles.</Text>
 		</Replace>
 
 		<!-- == MAORI == -->
@@ -776,7 +796,7 @@
 		<!-- == MAYA == -->
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_MUTAL_DESCRIPTION" Language="en_US">
-			<Text>Non-capital cities within 6 tiles of the [ICON_Capital] Capital gain +10% to all yields. Other non-capital cities receive -15% to all yields. +3 [ICON_Strength] Combat Strength to units within 6 tiles of the [ICON_Capital] Capital.</Text>
+			<Text>Non-capital cities within 6 tiles of the [ICON_Capital] Capital gain +5% to all yields. Other non-capital cities receive -10% to all yields.</Text>
 		</Replace>
 		<Replace Tag="LOC_ABILITY_MUTAL_COMBAT_STRENGTH_NEAR_CAPITAL_DESCRIPTION" Language="en_US">
 			<Text>+3 [ICON_Strength] Combat Strength to units within 6 tiles of the [ICON_Capital] Capital</Text>
@@ -853,33 +873,28 @@
 		<!-- == PERSIA == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_SATRAPIES_DESCRIPTION" Language="en_US">
-			<Text>+1 [ICON_TradeRoute] Trade Route capacity with Political Philosophy civic. Receive +2 [ICON_Gold] Gold and +1 [ICON_Culture] Culture for domestic Trade Routes, additional +2 [ICON_Gold] Gold from the Banking and Economics technologies, +2 [ICON_Culture] Culture from the Medieval Faires and Urbanization civics. Roads built in your territory are one level more advanced than usual.</Text>
+			<Text>+1 [ICON_TradeRoute] Trade Route capacity with Political Philosophy civic. Receive +2 [ICON_Gold] Gold for domestic Trade Routes, additional +2 [ICON_Gold] Gold from the Banking and Economics technologies. Roads built in your territory are one level more advanced than usual.</Text>
 		</Replace>
 		<!-- = leader ability (Cyrus) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_FALL_BABYLON_DESCRIPTION" Language="en_US">
-			<Text>All units get +3 [ICON_Strength] Combat Strength when attacking. No penalties to yields in occupied cities. Declaring a Surprise War only counts as a Formal War for the purpose of warmongering and war weariness.</Text>
+			<Text>All units get +3 [ICON_Strength] Combat Strength when attacking. No penalties to yields in occupied cities. Declaring a Surprise War only counts as a Formal War for the purpose of warmongering and war weariness.[NEWLINE][NEWLINE]Receive +1 [ICON_Culture] Culture for domestic Trade Routes, additional +2 [ICON_Culture] Culture from the Medieval Faires and Urbanization civics.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_LEADER_FALL_BABYLON_EXPANSION1_DESCRIPTION" Language="en_US">
-			<Text>All units get +3 [ICON_Strength] Combat Strength when attacking. +5 Loyalty per turn in occupied cities with a garrisoned unit. Declaring a Surprise War counts as a Formal War for the purpose of warmongering and war weariness.</Text>
+			<Text>All units get +3 [ICON_Strength] Combat Strength when attacking. +5 Loyalty per turn in occupied cities with a garrisoned unit. Declaring a Surprise War counts as a Formal War for the purpose of warmongering and war weariness.[NEWLINE][NEWLINE]Receive +1 [ICON_Culture] Culture for domestic Trade Routes, additional +2 [ICON_Culture] Culture from the Medieval Faires and Urbanization civics.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_LEADER_FALL_BABYLON_EXPANSION2_DESCRIPTION" Language="en_US">
-			<Text>All units get +3 [ICON_Strength] Combat Strength when attacking. +5 Loyalty per turn in occupied cities with a garrisoned unit. Declaring a Surprise War counts as a Formal War for the purposes of [ICON_STAT_GRIEVANCE] Grievances and warmongering.</Text>
+			<Text>All units get +3 [ICON_Strength] Combat Strength when attacking. +5 Loyalty per turn in occupied cities with a garrisoned unit. Declaring a Surprise War counts as a Formal War for the purposes of [ICON_STAT_GRIEVANCE] Grievances and warmongering.[NEWLINE][NEWLINE]Receive +1 [ICON_Culture] Culture for domestic Trade Routes, additional +2 [ICON_Culture] Culture from the Medieval Faires and Urbanization civics.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_FALLBABYLON_COMBAT_BONUS_DESCRIPTION" Language="en_US">
 			<Text>+{1_Value} when attacking (Cyrus)</Text>
 		</Replace>
 		<!-- = leader ability (Nader Shah) = -->
-		<!-- <Replace Tag="LOC_TRAIT_LEADER_NADER_SHAH_DESCRIPTION" Language="en_US">
-			<Text>+5 [ICON_Strength] Combat Strength when attacking full Health Units. Receive +3 [Icon_Faith] Faith and +3 [Icon_Gold] Gold on domestic [ICON_TradeRoute] Trade Routes.</Text>
+		<Replace Tag="LOC_TRAIT_LEADER_NADER_SHAH_DESCRIPTION" Language="en_US">
+			<Text>+5 [ICON_Strength] Combat Strength when attacking full Health Units.[NEWLINE][NEWLINE]Receive +1 [ICON_SCIENCE] Science for domestic Trade Routes, additional +2 [ICON_SCIENCE] Science from the Education and Scientific Theory technologies.</Text>
 		</Replace>
-		-->
-		<!-- <Replace Tag="LOC_ABILITY_NADER_SHAH_COMBAT_DESCRIPTION" Language="en_US">
-			<Text>+5 [ICON_Strength] Combat Strength when attacking district defenses or full Health units (Nader Shah)</Text>
-		</Replace>
-		-->
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_PAIRIDAEZA_DESCRIPTION" Language="en_US">
-			<Text>The Early Empire civic unlocks the Builder ability to construct a Pairidaeza, unique to Persia.[NEWLINE][NEWLINE]+1 [ICON_CULTURE] Culture, +2 [ICON_GOLD] Gold, and +1 Appeal to adjacent tiles.[NEWLINE][NEWLINE]+1 [ICON_CULTURE] Culture for each adjacent Holy Site, Campus, and Theater Square. +1 [ICON_GOLD] Gold for each adjacent Commercial Hub, Harbor, Industrial Zone, and City Center. Additional +1 [ICON_CULTURE] Culture with the Diplomatic Service civic. Provides [ICON_TOURISM] Tourism after researching Flight.[NEWLINE][NEWLINE]Cannot be built on Snow tiles, Tundra tiles or Floodplains. Cannot be build next to another Pairidaeza.</Text>
+			<Text>The Early Empire civic unlocks the Builder ability to construct a Pairidaeza, unique to Persia.[NEWLINE][NEWLINE]+1 [ICON_CULTURE] Culture, +2 [ICON_GOLD] Gold, +1 [ICON_HOUSING] Housing, and +1 Appeal to adjacent tiles.[NEWLINE][NEWLINE]+1 [ICON_CULTURE] Culture for each adjacent City Center, Holy Site, Campus, and Theater Square. +1 [ICON_GOLD] Gold for each adjacent City Center, Commercial Hub, Harbor, and Industrial Zone. Additional +1 [ICON_CULTURE] Culture with the Diplomatic Service civic. Provides [ICON_TOURISM] Tourism after researching Flight.[NEWLINE][NEWLINE]Cannot be built on Snow tiles, Tundra tiles or Floodplains. Cannot be build next to another Pairidaeza.</Text>
 		</Replace>
 		
 
@@ -955,7 +970,7 @@
 		<!-- == SCOTLAND == -->
 		<!-- leader ability-->
 		<Replace Tag="LOC_TRAIT_LEADER_BANNOCKBURN_DESCRIPTION" Language="en_US">
-			<Text>Recon and civilian units receive +1 [ICON_Movement] Movement if they begin their turn on hill tile.</Text>
+			<Text>Recon units and Settlers receive +1 [ICON_Movement] Movement if they begin their turn on hill tile.</Text>
 		</Replace>
 		<Row Tag="TRAIT_BANNOCKBURN_EXTRA_MOVEMENT_DESC" Language="en_US">
 			<Text>+1 [ICON_Movement] Movement if begin turn on hill tile (Bannockburn).</Text>
@@ -989,6 +1004,13 @@
 		</Replace>
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_TREASURE_FLEET_EXPANSION2_DESCRIPTION" Language="en_US">
 			<Text>May form [ICON_Corps] Fleets and [ICON_Army] Armadas earlier than usual (Mercenaries and Mercantilism). Once required Civics are unlocked, Shipyard building allows training [ICON_Corps] Fleets and [ICON_Army] Armadas directly and their costs reduced by 25%.[NEWLINE][NEWLINE][ICON_TradeRoute] Trade Routes receive +3 [ICON_Gold] Gold, +2 [ICON_Faith] Faith, and +1 [ICON_Production] Production. [ICON_TradeRoute] Trade Routes between multiple continents receive double these numbers. Cities at least 8 tiles away from [ICON_CAPITAL] Capital receive +25% [ICON_Production] Production towards [ICON_DISTRICT] districts.</Text>
+		</Replace>
+		<!-- = leader ability = -->
+		<Replace Tag="LOC_TRAIT_LEADER_EL_ESCORIAL_DESCRIPTION" Language="en_US">
+			<Text>Inquisitors can Remove Heresy one extra time. Combat and Religious units have a bonus of +3 [ICON_Strength] Combat Strength against players following other Religions.</Text>
+		</Replace>
+		<Replace Tag="LOC_TRAIT_LEADER_EL_ESCORIAL_EXPANSION2_DESCRIPTION" Language="en_US">
+			<Text>Inquisitors can Remove Heresy one extra time. Inquisitors eliminate 100% of the presence of other Religions. Combat and Religious units have a bonus of +3 [ICON_Strength] Combat Strength against players following other Religions.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_SPANISH_CONQUISTADOR_DESCRIPTION" Language="en_US">
@@ -1043,7 +1065,7 @@
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_SUMERIAN_WAR_CART_DESCRIPTION" Language="en_US">
-			<Text>Sumerian unique Ancient era unit. No penalties against anti-cavalry units. 4 [ICON_Movement] Movement if this unit starts in open terrain. +4 [ICON_Strength] Combat Strength when fighting [ICON_BARBARIAN] Barbarians.</Text>
+			<Text>Sumerian unique Ancient era unit. 4 [ICON_Movement] Movement if this unit starts in open terrain. Can escort moving civilian and support units at their higher [ICON_Movement] Movement speed. No penalties against anti-cavalry units. +4 [ICON_Strength] Combat Strength when fighting [ICON_BARBARIAN] Barbarians.</Text>
 		</Replace>
 		<Row Tag="LOC_ABILITY_WAR_CART_COMBAT_STRENGTH_VS_BARBS_DESCRIPTION_BBG" Language="en_US">
 			<Text>+4 [ICON_Strength] Combat Strength vs. Barbarians.[NEWLINE][ICON_Bullet] No penalties against anti-cavalry units.</Text>
@@ -1059,7 +1081,7 @@
 		<!-- == SWEDEN == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_NOBEL_PRIZE_DESCRIPTION" Language="en_US">
-			<Text>Sweden gains 50 [ICON_Favor] Diplomatic Favor (on Standard speed) when earning a [ICON_GreatPerson] Great Person. Having Sweden in the game adds three unique World Congress competitions starting in the Industrial Era.[NEWLINE][NEWLINE]+1 [ICON_GreatEngineer] Great Engineer point from Factories and +1 [ICON_GreatScientist] Great Scientist point from Universities. +50% [ICON_PRODUCTION] Production towards Libraries, Workshops, Universities, Factories and Government Plaza buildings.</Text>
+			<Text>Sweden gains 50 [ICON_Favor] Diplomatic Favor (on Standard speed) when earning a [ICON_GreatPerson] Great Person. Having Sweden in the game adds three unique World Congress competitions starting in the Industrial Era.[NEWLINE][NEWLINE]+1 [ICON_GreatEngineer] Great Engineer point from Factories and +1 [ICON_GreatScientist] Great Scientist point from Universities. +50% [ICON_PRODUCTION] Production towards Libraries, Workshops, Universities, Factories and Government Plaza buildings.[NEWLINE][NEWLINE]Non-capital cities in Desert, Tundra and Snow tiles receive +2 [ICON_FOOD] Food and +2 [ICON_PRODUCTION] Production.</Text>
 		</Replace>
 		<!-- = unique building = -->
 		<Replace Tag="LOC_BUILDING_QUEENS_BIBLIOTHEQUE_DESCRIPTION" Language="en_US">
@@ -1069,10 +1091,10 @@
 		<!-- == VIETNAM == -->
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_TRIEU_DESCRIPTION" Language="en_US">
-			<Text>+2 [ICON_Strength] Combat Strength for units fighting in Rainforest, Marsh, or Woods tiles. +1 [ICON_Movement] Movement if they begin their turn there. Both these bonuses are doubled if the tile is your territory.</Text>
+			<Text>+1 [ICON_Movement] Movement for all units beginning their turn in Rainforest, Marsh, or Woods tiles, doubled if the tile is your territory. +4 [ICON_Strength] Combat Strength for units fighting in these tiles in your territory.</Text>
 		</Replace>
 		<Replace Tag="LOC_ABILITY_TRIEU_FEATURES_DESCRIPTION" Language="en_US">
-			<Text>+2 [ICON_Strength] Combat Strength for units fighting in Rainforest, Marsh, or Woods tiles. +1 [ICON_Movement] Movement if they begin their turn there. Both these bonuses are doubled if the tile is your territory.</Text>
+			<Text>+1 [ICON_Movement] Movement for all units beginning their turn in Rainforest, Marsh, or Woods tiles, doubled if the tile is your territory. +4 [ICON_Strength] Combat Strength for units fighting in these tiles in your territory.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_VIETNAMESE_VOI_CHIEN_DESCRIPTION" Language="en_US">
@@ -1090,7 +1112,7 @@
 		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_AMABUTHO_DESCRIPTION" Language="en_US">
-			<Text>May form [ICON_Corps] Corps at the Mercenaries Civic and [ICON_Army] Armies at the Nationalism Civic, both gain +3 [ICON_STRENGTH] base Combat Strength at the Nationalism Civic and increasing to +5 [ICON_STRENGTH] base Combat Strength at the Mobilization Civic.</Text>
+			<Text>May form [ICON_Corps] Corps at the Mercenaries Civic and [ICON_Army] Armies at the Nationalism Civic, both gain +2 [ICON_STRENGTH] base Combat Strength at the Mobilization Civic.</Text>
 		</Replace>
 		<!-- = unique district = -->
 		<Replace Tag="LOC_DISTRICT_IKANDA_DESCRIPTION" Language="en_US">
@@ -1114,7 +1136,7 @@
 			<Text>Battle Meditation: +1 [ICON_Strength] Combat Strength for every researched civic (up to and including Industrial Era).</Text>
 		</Row>
 		<Replace Tag="LOC_UNIT_LAHORE_NIHANG_DESCRIPTION" Language="en_US">
-			<Text>Lahore City-State unique unit with a unique Promotion tree. Purchasable with [ICON_Faith] Faith. +15 [ICON_Strength] Combat Strength when Barracks, Armory, and Military Academy buildings are first constructed. Receives bonuses from [ICON_GREATGENERAL] Great General from any era.</Text>
+			<Text>Lahore City-state unique unit with a unique Promotion tree. Purchasable with [ICON_Faith] Faith. +15 [ICON_Strength] Combat Strength when Barracks, Armory, and Military Academy buildings are first constructed. Receives bonuses from [ICON_GREATGENERAL] Great General from any era.</Text>
 		</Replace>
 		<Replace Tag="LOC_UNIT_TRADER_DESCRIPTION" Language="en_US"> <!-- embarkation tip -->
 			<Text>May make and maintain a single [ICON_TradeRoute] Trade Route. Automatically creates Roads as it travels. Can embark since Celestial Navigation or Shipbuilding technology is researched.</Text>
@@ -1226,7 +1248,7 @@
 
 		<!-- == Liang == -->
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_BUILDER_GUILDMASTER_DESCRIPTION" Language="en_US">
-			<Text>All Builders trained in city get +1 [ICON_Charges] charge. Establishes in 3 turns.</Text>
+			<Text>All Builders trained in city get +1 [ICON_Charges] charge. Establishes in 4 turns.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_ZONING_COMMISSIONER_DESCRIPTION" Language="en_US">
 			<Text>+1 [ICON_Production] Production on the city's revealed resources.</Text>
@@ -1247,10 +1269,10 @@
 			<Text>Housing Boom</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_PARKS_RECREATION_DESCRIPTION" Language="en_US">
-			<Text>Can construct the City Park improvement on flat land in the city once Games and Recreation is unlocked. One per city. +3 [ICON_SCIENCE] Science, +3 [ICON_Culture] Culture, +3 [ICON_GOLD] Gold, +1 [ICON_HOUSING] Housing, +1 [ICON_Amenities] Amenity, and +2 Appeal.</Text>
+			<Text>Can construct the City Park improvement on flat land in the city once Games and Recreation civic is unlocked. +3 [ICON_SCIENCE] Science, +3 [ICON_Culture] Culture, +2 [ICON_HOUSING] Housing, +1 [ICON_Amenities] Amenity, and +2 Appeal to adjacent tiles. One per city.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_CITY_PARK_DESCRIPTION" Language="en_US">
-			<Text>A [ICON_Governor] Governor unique improvement that can be built in a city with a Surveyor Governor with the Parks and Recreation promotion. One per city. +3 [ICON_SCIENCE] Science, +3 [ICON_Culture] Culture, +3 [ICON_GOLD] Gold, +1 [ICON_HOUSING] Housing, +1 [ICON_Amenities] Amenity, and +2 Appeal to adjacent tiles.</Text>
+			<Text>A [ICON_Governor] Governor unique improvement that can be built in a city with a Surveyor Governor with the Parks and Recreation promotion. +3 [ICON_SCIENCE] Science, +3 [ICON_Culture] Culture, +2 [ICON_HOUSING] Housing, +1 [ICON_Amenities] Amenity, and +2 Appeal to adjacent tiles. One per city.</Text>
 		</Replace>
 
 		<!-- == Moksha == -->
@@ -1312,10 +1334,10 @@
 			<Text>+4 [ICON_Production] Production and +4 [ICON_POWER] Power provided by the city's Coal, Oil, or Nuclear Power Plant.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_RESOURCE_MANAGER_SURPLUS_LOGISTICS_DESCRIPTION" Language="en_US">
-			<Text>+20% [ICON_Food] Growth in the city. Your [ICON_TradeRoute] Trade Routes to Magnus' city provide +2 [ICON_Food] Food and +2 [ICON_PRODUCTION] Production to their starting city.</Text>
+			<Text>+20% [ICON_Food] Growth in the city. Your [ICON_TradeRoute] Trade Routes to Magnus' city provide +2 [ICON_Food] Food to their starting city.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_RESOURCE_MANAGER_EXPEDITION_DESCRIPTION" Language="en_US">
-			<Text>Settlers trained in the city do not consume a [ICON_Citizen] Population and gain +1 [ICON_Movement] Movement.</Text>
+			<Text>Settlers trained in the city do not consume a [ICON_Citizen] Population and gain +1 [ICON_Movement] Movement. Your [ICON_TradeRoute] Trade Routes to Magnus' city provide +2 [ICON_PRODUCTION] Production to their starting city.</Text>
 		</Replace>
 
 		<!-- == Ibrahim == -->
@@ -1360,7 +1382,7 @@
 			<Text>+1 [ICON_Production] Production and +1 [ICON_Faith] Faith from Quarries.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_CITY_PATRON_GODDESS_DESCRIPTION" Language="en_US">
-			<Text>+50% [ICON_Production] Production toward all [ICON_DISTRICT] districts in cities without a specialty [ICON_DISTRICT] district.</Text>
+			<Text>+40% [ICON_Production] Production toward all [ICON_DISTRICT] districts in cities without a specialty [ICON_DISTRICT] district.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_DANCE_OF_THE_AURORA_DESCRIPTION" Language="en_US">
 			<Text>Holy Site districts get +1 [ICON_Faith] Faith from adjacent flat Tundra tiles.</Text>
@@ -1536,7 +1558,7 @@
 			<Text>Unlocks the Builder ability to construct Fisheries.[NEWLINE][NEWLINE]+1 [ICON_Food] Food, +1 additional [ICON_Food] Food if adjacent to a sea resource. Must be built on a coastal plot.</Text>
 		</Replace>
 		<Replace Tag="LOC_ROUTE_RAILROAD_DESCRIPTION" Language="en_US">
-			<Text>Can only be constructed by Military Engineers. Does not cost a charge, but does cost 2 [ICON_RESOURCE_IRON] Iron.[NEWLINE][NEWLINE]Greatly improves [ICON_Movement] Movement speed of any unit moving from one Railroad tile to another. [ICON_TradeRoute] Trade Routes traveling over Railroads can multiply the [ICON_Gold] Gold they get from districts at their destination.</Text>
+			<Text>Can only be constructed by Military Engineers. Does not cost a charge, but does cost 1 [ICON_RESOURCE_IRON] Iron.[NEWLINE][NEWLINE]Greatly improves [ICON_Movement] Movement speed of any unit moving from one Railroad tile to another. [ICON_TradeRoute] Trade Routes traveling over Railroads can multiply the [ICON_Gold] Gold they get from districts at their destination.</Text>
 		</Replace>
 		
 
@@ -1782,7 +1804,7 @@
 			<Text>Grants 3 Archers, 3 Spearmen, and a Battering Ram. +35% [ICON_PRODUCTION] Production towards anti-cavalry units.[NEWLINE][NEWLINE]Must be built on flat land adjacent to an Encampment district with a Barracks.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_ORSZAGHAZ_DESCRIPTION" Language="en_US">
-			<Text>Additional +3 [ICON_Favor] Diplomatic Favor per City-State you are the Suzerain of.[NEWLINE][NEWLINE]Must be built on a River.</Text>
+			<Text>Additional +3 [ICON_Favor] Diplomatic Favor per City-state you are the Suzerain of.[NEWLINE][NEWLINE]Must be built on a River.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_KOTOKU_IN_DESCRIPTION" Language="en_US">
 			<Text>+20% [ICON_Faith] Faith in this city. Grants 4 Warrior Monks. Allows purchasing of Warrior Monks in this city regardless of city's Religion.[NEWLINE][NEWLINE]Must be built adjacent to a Holy Site district with a Temple.</Text>
@@ -1821,7 +1843,7 @@
 
 
 		<!-- === CITY-STATES === -->
-		<!-- BONUS tag for City-States picker, DESCRIPTION tag for gameplay description -->
+		<!-- BONUS tag for City-states picker, DESCRIPTION tag for gameplay description -->
 		<Replace Tag="LOC_CIVILIZATION_FEZ_BONUS" Language="en_US">
 			<Text>When you use a religious unit to convert a city for the first time earn 10 [ICON_SCIENCE] Science per [ICON_Citizen] Population of that city.</Text>
 		</Replace>
@@ -2166,7 +2188,6 @@
 		<Replace Tag="LOC_GREATPERSON_AETHELFLAED_ACTIVE" Language="en_US">
 			<Text>Instantly creates a Trebuchet unit with one promotion level.</Text>
 		</Replace>
-		<!-- Ana Nzinga - no text fixes -->
 		<Replace Tag="LOC_GREATPERSON_JOAN_OF_ARC_ACTIVE" Language="en_US">
 			<Text>Creates 1 [ICON_GreatWork_Relic] Relic. Has 2 charges.</Text>
 		</Replace>
@@ -2204,7 +2225,7 @@
 		<Replace Tag="LOC_GREATPERSON_WONDER_PURCHASE" Language="en_US">
 			<Text>Purchase [ICON_Production] Production towards wonder construction at the rate of 2 [ICON_GOLD] Gold per 1 [ICON_Production] Production.</Text>
 		</Replace>
-		<!-- Jamsetji Tata, Masaru Ibuka, Raja Todar Mal, John Spilsbury - no text fixes -->
+
 		<Replace Tag="LOC_GREATPERSON_CITY_STATE_ABSORB_EXPANSIONS" Language="en_US">
 			<Text>Absorbs this City-state into your empire. Grants you +10 Loyalty per turn in the city. Can be an enemy City-state.</Text>
 		</Replace>
@@ -2223,6 +2244,41 @@
 		</Replace>
 		<Replace Tag="LOC_GREATPERSON_ALAN_TURING_ACTIVE" Language="en_US">
 			<Text>Triggers the [ICON_TechBoosted] Eureka for Computers and 1 random technology from the Modern era. If Computers technology is already triggered, instead completes Computers technology.</Text>
+		</Replace>
+
+		<Replace Tag="LOC_ABILITY_CHOLA_NAVAL_UNITS_COMBAT_STRENGTH_DESCRIPTION" Language="en_US">
+			<Text>+{1_Amount} Combat Strength from Francis Drake</Text>
+		</Replace>
+
+
+
+		<!-- === ALLIANCES === -->
+		<Replace Tag="LOC_ALLIANCE_LV1_RESEARCH_EFFECT_2" Language="en_US">
+			<Text>+2 [ICON_SCIENCE] Science from [ICON_TradeRoute] Trade Routes from your ally</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV1_CULTURAL_EFFECT_2" Language="en_US">
+			<Text>+2 [ICON_Culture] Culture from [ICON_TradeRoute] Trade Routes from your ally</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV1_ECONOMIC_EFFECT_1" Language="en_US">
+			<Text>+6 [ICON_GOLD] Gold and +1 [ICON_PRODUCTION] from [ICON_TradeRoute] Trade Routes to your ally</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV1_ECONOMIC_EFFECT_2" Language="en_US">
+			<Text>+6 [ICON_GOLD] Gold and +1 [ICON_PRODUCTION] from [ICON_TradeRoute] Trade Routes from your ally</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV2_ECONOMIC_EFFECT_1" Language="en_US">
+			<Text>+1 [ICON_InfluencePerTurn] Influence Point per turn per City-state your ally is the Suzerain of</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV1_RELIGIOUS_EFFECT_1" Language="en_US">
+			<Text>+4 [ICON_FAITH] Faith from [ICON_TradeRoute] Trade Routes to your ally</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV1_RELIGIOUS_EFFECT_2" Language="en_US">
+			<Text>+4 [ICON_FAITH] Faith from [ICON_TradeRoute] Trade Routes from your ally</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV2_RELIGIOUS_EFFECT_1" Language="en_US">
+			<Text>+10 [ICON_RELIGION] Religious Combat Strength against non-ally Religions</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV3_MILITARY_EFFECT_1" Language="en_US">
+			<Text>Units start with a [ICON_Promotion] free Promotion</Text>
 		</Replace>
 
 


### PR DESCRIPTION
New text lines:
- Babylon UB - +1 production to farms (like Watermill) and +1 food for all improved freshwater tiles except farms;
- China, Qin Shi Huang (Unifier) leader ability - +50% production to Encampment buildings, Encampment grants +1 Great General points, Barracks building has 2 slots of Writing;
- Cree UU - combat descriptions tags (1st for battle preview and 2nd for portrait description);
- Dutch leader ability - combat descriptions (1st for battle preview and 2nd for portrait description);
- Egypt, Ramses II leader ability - 10% production as culture from buildings and 25% from Wonders;
- Egypt, Cleopatra (Ptolemaic) leader ability - resources on floodplains AND improved or under City Center grants +1 culture and +1 food;
- England, Elizabeth leader ability - +1 trade route capacity with Shipbuilding tech, Exploration civic and Mercantilism civic; naval raiders has +1 MP and +1 Sight;
- Germany, Ludwig II leader ability - for finished only;
- Mali UD - 5% discount;
- Persia, Nader-Shah leader ability - removed base-game traders ability; granted +1 science from internals, +2 from Education and Scientific Theory techs;
- Spain leader ability - +3 CS vs. heretics;
>
- Shrine HS building - can buy Monks;
- Temple HS building - removed line about Monks;
- Natural Wonders adjacency - Campus from mountains;
- Great Admiral Rajendra Chola battle preview - swapped with Francis Drake;
- Alliance lines - tuned up values (check at line 2255-2282); influence icon; religious combat strength icon; promotion icon.
>
Edited text lines:
- America, Abraham Lincoln leader ability - +100% to Aqueducts;
- Byzantium, Theodora leader ability - English text fix;
- Gran Colombia civilization ability - promoting only (all) Cavalry, Air and Spy units doesn't end turn (instead of all units);
- Cree UU - +5 vs. stronger units;
- Dutch leader ability - +3 when defending in Polder (UI);
- Dutch UI - unlocked with Feudalism;
- Gaul civilization ability - culture bomb on Mine with Iron Working;
- Hungary UU - English text fix;
- India, Chandragupta leader ability - removed +2 CS from T3 HS building; every building grants +1 CS; T3 grants Military Academy bonus;
- khmer leader ability - reverted culture bomb;
- Kongo civilization ability - English text fix;
- Kongo UU - removed +1 MP;
- Mali civilization ability - +2 faith from adjacent desert (like Indonesia) instead of +1 per adjacent desert tile; removed -30% chop penalty; reverted gold from mines; added -50% desert tiles discount;
- Maya leader ability - removed +3 CS near capital; decreased +-% values from +10/-15 to +5/-10 (cringy change sorry);
- Persia civilization ability - removed culture on internals (see Cyrus);
- Persia, Cyrus leader ability - added culture on internals;
- Persia UI - +1 base housing;
- Scotland leader ability - +1 MP for Recon and Settlers only;
- Sumeria UU - Escord ability;
- Sweden civilization ability - +2 food and +2 production if non-capital settled in desert/tundra/snow;
- Vietnam - removed +2 CS outside home territory;
- Zulu - removed additional CS on Nationalism, decreased to +2 for Mobilization;
>
- Nihang - English text fix;
- Liang T0 - establishes in 4 turns;
- Liang L2, Park - removed +3 gold, added +1 housing;
- Magnus L1 - removed +2 production on internals, moved to R1;
- Magnus R1 - added +2 production on internals;
- City Patron Goddess pantheon - 40% production (from 50%);
- Railroad - 1 Iron cost (from 2);
- Orszaghaz World wonder - English text fix.

Deleted text lines:
- Columbia UU Comandante - clean unused commented lines;
- Greece civilization ability - reverted to base-game.

Ignored patch changes:
- Mining jungle chop - removed from this build.

[Database.log](https://github.com/CivilizationVIBetterBalancedGame/BetterBalancedGame/files/11328123/Database.log)