### PR TITLE
french 5.8 (beta)

### DIFF
--- a/lang/french.xml
+++ b/lang/french.xml
@@ -3981,10 +3981,10 @@
 			<Text>La ressource de luxe choisie n'octroie pas [ICON_AMENITIES] d'Activité.</Text>
 		</Replace>
 		<Replace Tag="LOC_WORLD_CONGRESS_BUFF_PRODUCTION_YIELD_DESC" Language="fr_FR">
-			<Text>Le coût en Production ou d'achat des unités militaires est réduit de 25% jusqu'au prochain Congrès mondial.</Text>
+			<Text>Le coût en Production ou d'achat des unités militaires est réduit de 50% jusqu'au prochain Congrès mondial.</Text>
 		</Replace>
 		<Replace Tag="LOC_WORLD_CONGRESS_BAN_PRODUCTION_YIELD_DESC" Language="fr_FR">
-			<Text>Le coût en Production ou d'achat des unités militaires est augmenté de 50% jusqu'au prochain Congrès mondial.</Text>
+			<Text>Le coût en Production ou d'achat des unités militaires est augmenté de 100% jusqu'au prochain Congrès mondial.</Text>
 		</Replace>
 		<Replace Tag="LOC_WORLD_CONGRESS_BUFF_ARMS_CONTROL_DESC" Language="fr_FR">
 			<Text>Les armes de destruction massive de tous les joueurs sont réglées sur le niveau de celles du joueur ciblé.</Text>

--- a/lang/french.xml
+++ b/lang/french.xml
@@ -96,7 +96,7 @@
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_AMERICAN_P51_DESCRIPTION" Language="fr_FR">
-			<Text>Exclusive à l'Amérique, cet avion de chasse atomique remplace le Chasseur. [ICON_RANGE] Portée d'attaque +2. [ICON_STRENGTH] Puissance de combat +5 contre les chasseurs et Expérience de combat +50 %.</Text>
+			<Text>Exclusive à l'Amérique, cet avion de chasse atomique remplace le Chasseur. [ICON_RANGE] Portée d'attaque +2. [ICON_STRENGTH] Puissance de combat +5 contre les chasseurs et Expérience de combat +50 %.</Text>
 		</Replace>
 		<!-- = unique building = -->
 		<Replace Tag="LOC_BUILDING_FILM_STUDIO_EXPANSION2_DESCRIPTION" Language="fr_FR">
@@ -120,7 +120,7 @@
 		</Replace>
 		<!-- = leader ability (Saladin Sultan) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_SALADIN_ALT_DESCRIPTION" Language="fr_FR">
-			<Text>Bonus de contournement et de soutien +100% pour toutes les unités religieuses et militaires.</Text>
+			<Text>Bonus de contournement et de soutien +100% pour toutes les unités religieuses et militaires. Coût d'entretien -1 pour les unités militaires.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_ARABIAN_MAMLUK_DESCRIPTION" Language="fr_FR">
@@ -146,13 +146,13 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_OUTBACK_STATION_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de contruire un élevage de l'Outback, exclusif à l'Australie.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1, [ICON_PRODUCTION] Production +1 et [ICON_HOUSING] Habitations +0,5.[NEWLINE][ICON_FOOD] Nourriture +1 pour chaque pâturage adjacent. [ICON_FOOD] Nourriture +1 tous les deux élevages de l'Outback adjacents à Déploiement Rapide. [ICON_PRODUCTION] Production +1 tous les deux élevages de l'Outback adjacents à l'Industrialisation. [ICON_PRODUCTION] Production +1 pour les pâturages pour chaque élevage de l'Outback adjacent à l'Industrialisation. Attrait +1 pour les cases adjacentes.[NEWLINE][NEWLINE]Ne peut être construit que dans un désert, une prairie ou une plaine.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de contruire un élevage de l'Outback, exclusif à l'Australie.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1, [ICON_PRODUCTION] Production +1 et [ICON_HOUSING] Habitations +0,5.[NEWLINE][ICON_FOOD] Nourriture +1 pour chaque pâturage adjacent. [ICON_FOOD] Nourriture +1 tous les deux élevages de l'Outback adjacents à Déploiement Rapide. [ICON_PRODUCTION] Production +1 tous les deux élevages de l'Outback adjacents à l'Industrialisation. [ICON_PRODUCTION] Production +1 pour les pâturages pour chaque élevage de l'Outback adjacent à l'Industrialisation. Attrait +1 pour les cases adjacentes.[NEWLINE][NEWLINE]Ne peut être construit que dans un désert, une prairie ou une plaine.</Text>
 		</Replace>
 
 		<!-- == AZTECS - AZTÈQUES == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_LEGEND_FIVE_SUNS_DESCRIPTION" Language="fr_FR">
-			<Text>Dépensez une [ICON_CHARGES] charge de bâtisseur pour compléter 30% du coût en [ICON_PRODUCTION] Production d'un [ICON_DISTRICT] quartier.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +50% pour les unités militaires terrestres de combat rapproché.</Text>
+			<Text>Dépensez une [ICON_CHARGES] charge de Bâtisseur pour compléter 30% du coût en [ICON_PRODUCTION] Production d'un [ICON_DISTRICT] quartier.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +50% pour les unités militaires terrestres de combat rapproché.</Text>
 		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_GIFTS_FOR_TLATOANI_DESCRIPTION" Language="fr_FR">
@@ -161,7 +161,7 @@
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_AZTEC_EAGLE_WARRIOR_DESCRIPTION" Language="fr_FR">
-			<Text>Exclusive aux Aztèques, cette unité antique de combat rapproché remplace le Guerrier. [ICON_STRENGTH] Puissance de base +8. Après une victoire militaire, a une chance de réduire en esclavage l'unité vaincue et d'en faire un bâtisseur.</Text>
+			<Text>Exclusive aux Aztèques, cette unité antique de combat rapproché remplace le Guerrier. [ICON_STRENGTH] Puissance de base +8. Après une victoire militaire, a une chance de réduire en esclavage l'unité vaincue et d'en faire un Bâtisseur.</Text>
 		</Replace>
 		<!-- = unique building = -->
 		<Replace Tag="LOC_BUILDING_TLACHTLI_XP1_DESCRIPTION" Language="fr_FR">
@@ -281,7 +281,7 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_ICE_HOCKEY_RINK_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une patinoire, exclusive au Canada.[NEWLINE][NEWLINE][ICON_AMENITIES] Activités +1. Attrait +2 pour les cases adjacentes.[NEWLINE][ICON_FOOD] Nourriture +2 et [ICON_PRODUCTION] Production +2 une fois le Sport Professionnel débloqué. [ICON_CULTURE] Culture +1 pour chaque case adjacente de toundra, de colline de toundra, de neige ou de colline enneigée. [ICON_CULTURE] Culture +4 si adjacente à un stade. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte.[NEWLINE][NEWLINE]Peut être construite sur une case de toundra, de colline de toundra, de neige ou de colline enneigée. Une par ville.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une patinoire, exclusive au Canada.[NEWLINE][NEWLINE][ICON_AMENITIES] Activités +1. Attrait +2 pour les cases adjacentes.[NEWLINE][ICON_FOOD] Nourriture +2 et [ICON_PRODUCTION] Production +2 une fois le Sport Professionnel débloqué. [ICON_CULTURE] Culture +1 pour chaque case adjacente de toundra, de colline de toundra, de neige ou de colline enneigée. [ICON_CULTURE] Culture +4 si adjacente à un stade. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte.[NEWLINE][NEWLINE]Peut être construite sur une case de toundra, de colline de toundra, de neige ou de colline enneigée. Une par ville.</Text>
 		</Replace>
 
 		<!-- == CHINA - CHINE == -->
@@ -291,7 +291,7 @@
 		</Replace>
 		<!-- = leader ability (Qin Shi Huang, Mandate of Heaven) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_FIRST_EMPEROR_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>Les bâtisseurs reçoivent une [ICON_CHARGES] charge supplémentaire. Vous pouvez dépenser une [ICON_CHARGES] charge de bâtisseur pour compléter 15% du coût de [ICON_PRODUCTION] Production d'une merveille des ères antique ou classique.[NEWLINE][NEWLINE]Les Canaux sont débloqués à Maçonnerie.</Text>
+			<Text>Les Bâtisseurs reçoivent une [ICON_CHARGES] charge supplémentaire. Vous pouvez dépenser une [ICON_CHARGES] charge de Bâtisseur pour compléter 15% du coût de [ICON_PRODUCTION] Production d'une merveille des ères antique ou classique.[NEWLINE][ICON_FOOD] Nourriture +1 pour les villes pour chaque merveilles mondiales construites.[NEWLINE][NEWLINE]Les Canaux sont débloqués à Maçonnerie.</Text>
 		</Replace>
 		<!-- = leader ability (Qin Shi Huang, Unifier) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_QIN_ALT_DESCRIPTION" Language="fr_FR">
@@ -326,7 +326,7 @@
 		</Row>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_GREAT_WALL_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire la Grande Muraille, exclusive à la Chine.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1.[NEWLINE][ICON_GOLD] Or +1 pour chaque segment adjacent. [ICON_CULTURE] Culture +1 pour chaque segment adjacent aux Châteaux. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte.[NEWLINE][NEWLINE][ICON_STRENGTH] Puissance de combat en défense +4 et gain instantané de 2 tours de retranchement. [NEWLINE][NEWLINE]Doit être construite sur une ligne longeant la frontière de votre Empire. Peut uniquement être pillée, mais jamais détruite par les catastrophes naturelles.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire la Grande Muraille, exclusive à la Chine.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1.[NEWLINE][ICON_GOLD] Or +1 pour chaque segment adjacent. [ICON_CULTURE] Culture +1 pour chaque segment adjacent aux Châteaux. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte.[NEWLINE][NEWLINE][ICON_STRENGTH] Puissance de combat en défense +4 et gain instantané de 2 tours de retranchement. [NEWLINE][NEWLINE]Doit être construite sur une ligne longeant la frontière de votre Empire. Peut uniquement être pillée, mais jamais détruite par les catastrophes naturelles.</Text>
 		</Replace>
 
 		<!-- == COLOMBIA - COLOMBIE == -->
@@ -350,7 +350,7 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_HACIENDA_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une hacienda, un aménagement exclusif à la Grande Colombie.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1, [ICON_GOLD] Or +2 et [ICON_HOUSING] Habitations +0.5.[NEWLINE][ICON_FOOD] Nourriture +1 toutes les 2 cases de plantations adjacentes (pour chaque plantation après la découverte des Pièces Détachées).[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1 pour les plantations et les haciendas, toutes les 2 haciendas adjacentes (pour chaque hacienda adjacente au Mercantilisme).[NEWLINE][NEWLINE]Ne peut être construite que sur une case de plaine ou de prairie.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une hacienda, un aménagement exclusif à la Grande Colombie.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1, [ICON_GOLD] Or +2 et [ICON_HOUSING] Habitations +0.5.[NEWLINE][ICON_FOOD] Nourriture +1 toutes les 2 cases de plantations adjacentes (pour chaque plantation après la découverte des Pièces Détachées).[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1 pour les plantations et les haciendas, toutes les 2 haciendas adjacentes (pour chaque hacienda adjacente au Mercantilisme).[NEWLINE][NEWLINE]Ne peut être construite que sur une case de plaine ou de prairie.</Text>
 		</Replace>
 
 		<!-- == CREE - CRIS == -->
@@ -374,7 +374,7 @@
 		</Row>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_MEKEWAP_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un mekewap, exclusif aux Cris.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1 et [ICON_HOUSING] Habitations +1.[NEWLINE][ICON_FOOD] Nourriture +1 toutes les 2 ressources bonus adjacentes (pour chaque ressource bonus adjacente à la Conservation). [ICON_PRODUCTION] Production +1 et [ICON_HOUSING] Habitations +1 à Fonction Publique. [ICON_GOLD] Or +1 si adjacent à une ressource de luxe. [ICON_GOLD] Or +2 par ressource de luxe adjacente à la Cartographie.[NEWLINE][NEWLINE]Doit être placé adjacent à une ressource bonus ou de luxe. Ne peut pas être adjacent à un autre mekewap.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un mekewap, exclusif aux Cris.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1 et [ICON_HOUSING] Habitations +1.[NEWLINE][ICON_FOOD] Nourriture +1 toutes les 2 ressources bonus adjacentes (pour chaque ressource bonus adjacente à la Conservation). [ICON_PRODUCTION] Production +1 et [ICON_HOUSING] Habitations +1 à Fonction Publique. [ICON_GOLD] Or +1 si adjacent à une ressource de luxe. [ICON_GOLD] Or +2 par ressource de luxe adjacente à la Cartographie.[NEWLINE][NEWLINE]Doit être placé adjacent à une ressource bonus ou de luxe. Ne peut pas être adjacent à un autre mekewap.</Text>
 		</Replace>
 
 		<!-- == DUTCH - NETHERLANDS - PAYS-BAS == -->
@@ -398,13 +398,13 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_POLDER_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un polder, exclusif aux Pays-Bas.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1, [ICON_PRODUCTION] Production +1 et [ICON_HOUSING] Habitations +0,5.[NEWLINE][ICON_FOOD] Nourriture +1 pour chaque polder adjacent (+2 à Pièces de Rechange). [ICON_PRODUCTION] Production +1 tous les deux polders adjacents (pour chaque polder adjacent à Pièces de Rechange). [ICON_PRODUCTION] Production +1 pour chaque Port adjacent. [ICON_GOLD] Or +4 à Génie Civil.[NEWLINE][NEWLINE]Doit être placé sur une case de côte ou de lac adjacente à au moins une case de terre franchissable.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un polder, exclusif aux Pays-Bas.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1, [ICON_PRODUCTION] Production +1 et [ICON_HOUSING] Habitations +0,5.[NEWLINE][ICON_FOOD] Nourriture +1 pour chaque polder adjacent (+2 à Pièces de Rechange). [ICON_PRODUCTION] Production +1 tous les deux polders adjacents (pour chaque polder adjacent à Pièces de Rechange). [ICON_PRODUCTION] Production +1 pour chaque Port adjacent. [ICON_GOLD] Or +4 à Génie Civil.[NEWLINE][NEWLINE]Doit être placé sur une case de côte ou de lac adjacente à au moins une case de terre franchissable.</Text>
 		</Replace>
 
 		<!-- == EGYPT - ÉGYPTE == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_ITERU_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +25% pour les [ICON_DISTRICT] quartiers et merveilles adjacents à une rivière. Ne subit aucun dégât d'inondation.</Text>
+			<Text>[ICON_PRODUCTION] Production +20% pour les [ICON_DISTRICT] quartiers et merveilles adjacents à une rivière. Ne subit aucun dégât d'inondation.</Text>
 		</Replace>
 		<!-- = leader ability (Cleopatra Egyptian - Cléopâtre Égyptienne) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_MEDITERRANEAN_EXPANSION2_DESCRIPTION" Language="fr_FR">
@@ -430,14 +430,23 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_SPHINX_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la capacité de bâtisseur de construire un sphinx, exclusif à l'Égypte.[NEWLINE][NEWLINE][ICON_CULTURE] Culture +1 et [ICON_FAITH] Foi +2.[NEWLINE][ICON_FOOD] Nourriture +1 et [ICON_PRODUCTION] Production +1 si construit sur un désert. [ICON_CULTURE] Culture +1 si construit sur des plaines inondables. [ICON_CULTURE] Culture +1 au Service Diplomatique. [ICON_CULTURE] Culture +1 et [ICON_FAITH] Foi +1 si adjacent à une merveille. Attrait +2 pour les cases adjacentes.[NEWLINE]Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte.[NEWLINE][NEWLINE]Ne peut pas être construit à côté d'un autre sphinx, ni sur une case de neige ou une colline enneigée.</Text>
+			<Text>Débloque la capacité de Bâtisseur de construire un sphinx, exclusif à l'Égypte.[NEWLINE][NEWLINE][ICON_CULTURE] Culture +1 et [ICON_FAITH] Foi +2.[NEWLINE][ICON_FOOD] Nourriture +1 et [ICON_PRODUCTION] Production +1 si construit sur un désert. [ICON_CULTURE] Culture +1 si construit sur des plaines inondables. [ICON_CULTURE] Culture +1 au Service Diplomatique. [ICON_CULTURE] Culture +1 et [ICON_FAITH] Foi +1 si adjacent à une merveille. Attrait +2 pour les cases adjacentes.[NEWLINE]Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte.[NEWLINE][NEWLINE]Ne peut pas être construit à côté d'un autre sphinx, ni sur une case de neige ou une colline enneigée.</Text>
 		</Replace>
 
 		<!-- == (LEADER) ELEANOR - ALIÉNOR == -->
-		<!-- = leader ability = -->
+		<!-- = temporary = -->
 		<Replace Tag="LOC_TRAIT_LEADER_ELEANOR_LOYALTY_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +100% pour la construction des bâtiments de la Place du théâtre.[NEWLINE][ICON_PRODUCTION] Production +20% pour les merveilles des ères antiques et classiques (Aliénor-France uniquement).[NEWLINE][NEWLINE]Les chefs-d'œuvre [ICON_GREATWORK_WRITING] littéraires et les [ICON_GREATWORK_RELIC] reliques, les chefs-d'œuvre [ICON_GREATWORK_LANDSCAPE] artistiques et les [ICON_GREATWORK_ARTIFACT] artéfacts, et les chefs-d'œuvre [ICON_GREATWORK_MUSIC] musicaux reçoivent des rendements supplémentaires en fonction des [ICON_DISTRICT] quartiers présents dans la ville :[NEWLINE] • [ICON_FOOD] Nourriture +1/+2/+4 pour un Quartier résidentiel.[NEWLINE] • [ICON_PRODUCTION] Production +1/+2/+4 pour une Zone industrielle.[NEWLINE] • [ICON_GOLD] Or +1/+2/+4 pour un Port et/ou une Plateforme commerciale.[NEWLINE] • [ICON_SCIENCE] Science +1/+2/+4 pour un Campus.[NEWLINE] • [ICON_CULTURE] Culture +1/+2/+4 pour une Place du théâtre.[NEWLINE] • [ICON_FAITH] Foi +1/+2/+4 pour un Lieu saint.[NEWLINE]Le bonus de suzerain d'Anshan ne peut pas être utilisé par Aliénor.[NEWLINE][NEWLINE]Loyauté -1 par tour dans les villes étrangères pour chaque chef-d'œuvre présent dans l'une des villes d'Aliénor, dans un rayon de 9 cases. Une ville qui devient libre sous l'influence d'Aliénor rejoint celle-ci directement.</Text>
+		</Replace>
+		<!-- = leader ability - England = -->
+		<Replace Tag="LOC_TRAIT_LEADER_ELEANOR_ENGLISH_LOYALTY_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_PRODUCTION] Production +100% pour la construction des bâtiments de la Place du théâtre.[NEWLINE][NEWLINE]Les chefs-d'œuvre [ICON_GREATWORK_WRITING] littéraires et les [ICON_GREATWORK_RELIC] reliques, les chefs-d'œuvre [ICON_GREATWORK_LANDSCAPE] artistiques et les [ICON_GREATWORK_ARTIFACT] artéfacts, et les chefs-d'œuvre [ICON_GREATWORK_MUSIC] musicaux reçoivent des rendements supplémentaires en fonction des [ICON_DISTRICT] quartiers présents dans la ville :[NEWLINE] • [ICON_FOOD] Nourriture +1/+2/+4 pour un Quartier résidentiel.[NEWLINE] • [ICON_PRODUCTION] Production +1/+2/+4 pour une Zone industrielle.[NEWLINE] • [ICON_GOLD] Or +1/+2/+4 pour un Port et/ou une Plateforme commerciale.[NEWLINE] • [ICON_SCIENCE] Science +1/+2/+4 pour un Campus.[NEWLINE] • [ICON_CULTURE] Culture +1/+2/+4 pour une Place du théâtre.[NEWLINE] • [ICON_FAITH] Foi +1/+2/+4 pour un Lieu saint.[NEWLINE]Le bonus de suzerain d'Anshan ne peut pas être utilisé par Aliénor.[NEWLINE][NEWLINE]Loyauté -1 par tour dans les villes étrangères pour chaque chef-d'œuvre présent dans l'une des villes d'Aliénor, dans un rayon de 9 cases. Une ville qui devient libre sous l'influence d'Aliénor rejoint celle-ci directement.</Text>
 		</Replace>
+		<!-- = leader ability - France = -->
+		<Replace Tag="LOC_TRAIT_LEADER_ELEANOR_FRENCH_LOYALTY_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +100% pour la construction des bâtiments de la Place du théâtre.[NEWLINE][ICON_PRODUCTION] Production +20% pour les merveilles des ères antiques et classiques.[NEWLINE][NEWLINE]Les chefs-d'œuvre [ICON_GREATWORK_WRITING] littéraires et les [ICON_GREATWORK_RELIC] reliques, les chefs-d'œuvre [ICON_GREATWORK_LANDSCAPE] artistiques et les [ICON_GREATWORK_ARTIFACT] artéfacts, et les chefs-d'œuvre [ICON_GREATWORK_MUSIC] musicaux reçoivent des rendements supplémentaires en fonction des [ICON_DISTRICT] quartiers présents dans la ville :[NEWLINE] • [ICON_FOOD] Nourriture +1/+2/+4 pour un Quartier résidentiel.[NEWLINE] • [ICON_PRODUCTION] Production +1/+2/+4 pour une Zone industrielle.[NEWLINE] • [ICON_GOLD] Or +1/+2/+4 pour un Port et/ou une Plateforme commerciale.[NEWLINE] • [ICON_SCIENCE] Science +1/+2/+4 pour un Campus.[NEWLINE] • [ICON_CULTURE] Culture +1/+2/+4 pour une Place du théâtre.[NEWLINE] • [ICON_FAITH] Foi +1/+2/+4 pour un Lieu saint.[NEWLINE]Le bonus de suzerain d'Anshan ne peut pas être utilisé par Aliénor.[NEWLINE][NEWLINE]Loyauté -1 par tour dans les villes étrangères pour chaque chef-d'œuvre présent dans l'une des villes d'Aliénor, dans un rayon de 9 cases. Une ville qui devient libre sous l'influence d'Aliénor rejoint celle-ci directement.</Text>
+		</Replace>
+
 
 		<!-- == ENGLAND - ANGLETERRE == -->
 		<!-- = civilization ability = -->
@@ -483,7 +492,7 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_ROCK_HEWN_CHURCH_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une église rupestre, un aménagement exclusif à l'Éthiopie.[NEWLINE][NEWLINE][ICON_FAITH] Foi +1 pour chaque case de collines ou de montagnes adjacente. Attrait +1 pour les cases adjacentes. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_FAITH] Foi une fois l'Aviation découverte.[NEWLINE][NEWLINE]Ne peut pas être détruite par les catastrophes naturelles. Ne peut être construite que sur une colline ou un sol volcanique n'étant pas adjacent à une autre église rupestre.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une église rupestre, un aménagement exclusif à l'Éthiopie.[NEWLINE][NEWLINE][ICON_FAITH] Foi +1 pour chaque case de collines ou de montagnes adjacente. Attrait +1 pour les cases adjacentes. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_FAITH] Foi une fois l'Aviation découverte.[NEWLINE][NEWLINE]Ne peut pas être détruite par les catastrophes naturelles. Ne peut être construite que sur une colline ou un sol volcanique n'étant pas adjacent à une autre église rupestre.</Text>
 		</Replace>
 
 		<!-- == FRANCE == -->
@@ -511,7 +520,7 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_CHATEAU_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un castel, exclusif à la France.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1, [ICON_GOLD] Or +1, [ICON_CULTURE] Culture +1 et [ICON_HOUSING] Habitations +1.[NEWLINE][ICON_GOLD] Or +2 si placé sur une rivière. [ICON_GOLD] Or +1 et [ICON_CULTURE] Culture +1 pour chaque ressource de luxe adjacente. [ICON_CULTURE] Culture +1 pour chaque merveille adjacente (+2 à Aviation). Attrait +1 pour les cases adjacentes.[NEWLINE]Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte.[NEWLINE][NEWLINE]Construction impossible sur une case adjacente à un autre castel.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un castel, exclusif à la France.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1, [ICON_GOLD] Or +1, [ICON_CULTURE] Culture +1 et [ICON_HOUSING] Habitations +1.[NEWLINE][ICON_GOLD] Or +2 si placé sur une rivière. [ICON_GOLD] Or +1 et [ICON_CULTURE] Culture +1 pour chaque ressource de luxe adjacente. [ICON_CULTURE] Culture +1 pour chaque merveille adjacente (+2 à Aviation). Attrait +1 pour les cases adjacentes.[NEWLINE]Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte.[NEWLINE][NEWLINE]Construction impossible sur une case adjacente à un autre castel.</Text>
 		</Replace>
 
 		<!-- == GAUL - GAULE == -->
@@ -562,7 +571,7 @@
 		<!-- == GERMANY - ALLEMAGNE == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_IMPERIAL_FREE_CITIES_DESCRIPTION" Language="fr_FR">
-			<Text>Une fois les Guildes découvertes, chaque ville peut construire un [ICON_DISTRICT] quartier spécialisé de plus, au-delà du seuil imposé par les [ICON_CITIZEN] Citoyens.</Text>
+			<Text>Une fois les Guildes découvertes, chaque ville peut construire un [ICON_DISTRICT] quartier spécialisé de plus, au-delà du seuil imposé par les [ICON_CITIZEN] Citoyens.[NEWLINE]Les Plateformes commerciales déclenchent une bombe culturelle à leur complétion.</Text>
 		</Replace>
 		<!-- = leader ability (Frederick Barbarossa) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_HOLY_ROMAN_EMPEROR_DESCRIPTION" Language="fr_FR">
@@ -625,7 +634,7 @@
 		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_RAVEN_KING_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_STRENGTH] Puissance de combat +3 et [ICON_MOVEMENT] PM +1 pour les unités levées de Cités-états. Améliorer des unités levées coûte 75% [ICON_GOLD] d'Or et de ressources en moins. Si vous levez les troupes d'une Cité-état, vous y recevez 1 [ICON_ENVOY] émissaire.[NEWLINE][NEWLINE]Tous les [ICON_GOVERNMENT] gouvernements ont un emplacement de doctrine Diplomatique supplémentaire.</Text>
+			<Text>[ICON_STRENGTH] Puissance de combat +3 et [ICON_MOVEMENT] PM +1 pour les unités levées de Cités-états. Améliorer des unités levées coûte 75% [ICON_GOLD] d'Or et de ressources en moins. Si vous levez les troupes d'une Cité-état, vous y recevez 1 [ICON_ENVOY] émissaire.</Text>
 		</Replace>
 		<!-- = unique building = -->
 		<Replace Tag="LOC_BUILDING_THERMAL_BATH_DESCRIPTION" Language="fr_FR">
@@ -660,11 +669,11 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_TERRACE_FARM_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une culture en terrasses, exclusive aux Incas.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1 et [ICON_HOUSING] Habitations +1.[NEWLINE][ICON_FOOD] Nourriture +1 pour chaque montagne adjacente. [ICON_PRODUCTION] Production +2 pour chaque Aqueduc adjacent. [ICON_PRODUCTION] Production +1 si adjacente à de l'eau douce, mais pas à un aqueduc. [ICON_FOOD] Nourriture +1 toutes les 2 cultures en terrasses adjacentes (pour chaque culture en terrasses à Pièces de rechange).[NEWLINE][NEWLINE]Ne peut être placée que sur des collines de prairie, de plaine et de désert.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une culture en terrasses, exclusive aux Incas.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1 et [ICON_HOUSING] Habitations +1.[NEWLINE][ICON_FOOD] Nourriture +1 pour chaque montagne adjacente. [ICON_PRODUCTION] Production +2 pour chaque Aqueduc adjacent. [ICON_PRODUCTION] Production +1 si adjacente à de l'eau douce, mais pas à un aqueduc. [ICON_FOOD] Nourriture +1 toutes les 2 cultures en terrasses adjacentes (pour chaque culture en terrasses à Pièces de rechange).[NEWLINE][NEWLINE]Ne peut être placée que sur des collines de prairie, de plaine et de désert.</Text>
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_MOUNTAIN_ROAD_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un Qhapaq Ñan, exclusif à Pachacutec.[NEWLINE][NEWLINE]Fait office de portail de déplacement sur une chaîne de montagnes : les unités entrent dans un portail et ressortent par un autre pour 2 [ICON_MOVEMENT] PM. Augmente [ICON_GOLD] l'Or reçu des [ICON_TRADEROUTE] routes commerciales traversant le Qhapaq Ñan.[NEWLINE][NEWLINE]Ne peut pas être pillée ou supprimée.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un Qhapaq Ñan, exclusif à Pachacutec.[NEWLINE][NEWLINE]Fait office de portail de déplacement sur une chaîne de montagnes : les unités entrent dans un portail et ressortent par un autre pour 2 [ICON_MOVEMENT] PM. Augmente [ICON_GOLD] l'Or reçu des [ICON_TRADEROUTE] routes commerciales traversant le Qhapaq Ñan.[NEWLINE][NEWLINE]Ne peut pas être pillée ou supprimée.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_INCA_WARAKAQ_DESCRIPTION" Language="fr_FR">
@@ -706,7 +715,7 @@
 		</Row>
 		<!-- = leader ability (Gandhi) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_SATYAGRAHA_DESCRIPTION" Language="fr_FR">
-			<Text>Octroie une croyance supplémentaire à la fondation d'une [ICON_RELIGION] religion.[NEWLINE][ICON_FAITH] Foi +5 pour chaque civilisation rencontrée (y compris l'Inde) ayant fondé une [ICON_RELIGION] religion et n'étant pas en guerre.[NEWLINE][ICON_MOVEMENT] PM +1 pour les Bâtisseurs et les Colons.[NEWLINE][NEWLINE]L'usure de la guerre est doublée pour les civilisations qui combattent Gandhi.</Text>
+			<Text>Octroie une croyance supplémentaire à la fondation d'une [ICON_RELIGION] religion.[NEWLINE][ICON_FAITH] Foi +5 pour chaque civilisation rencontrée (y compris l'Inde) ayant fondé une [ICON_RELIGION] religion et n'étant pas en guerre.[NEWLINE][ICON_MOVEMENT] PM +1 pour les Bâtisseurs et les Colons.[NEWLINE][NEWLINE]L'usure de la guerre +50% pour les civilisations qui combattent Gandhi.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_INDIAN_VARU_DESCRIPTION" Language="fr_FR">
@@ -714,7 +723,7 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_STEPWELL_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un puits à degrés, exclusif à l'Inde.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1, [ICON_FAITH] Foi +1 et [ICON_HOUSING] Habitations +1. [ICON_FOOD] Nourriture +1 pour chaque ferme adjacente. [ICON_FAITH] Foi +1 si adjacent à un Lieu saint.[NEWLINE][NEWLINE]Construction impossible sur une colline ou adjacent à un autre puits à degrés.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un puits à degrés, exclusif à l'Inde.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1, [ICON_FAITH] Foi +1 et [ICON_HOUSING] Habitations +1. [ICON_FOOD] Nourriture +1 pour chaque ferme adjacente. [ICON_FAITH] Foi +1 si adjacent à un Lieu saint.[NEWLINE][NEWLINE]Construction impossible sur une colline ou adjacent à un autre puits à degrés.</Text>
 		</Replace>
 
 		<!-- == INDONESIA - INDONÉSIE == -->
@@ -728,7 +737,7 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_KAMPUNG_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un kampung, exclusif à l'Indonésie.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1 et [ICON_HOUSING] Habitations +1.[NEWLINE][ICON_FOOD] Nourriture +1 et [ICON_FAITH] Foi +1 pour chaque bateau de pêche adjacent. [ICON_PRODUCTION] Production +1 à Génie Civil.[NEWLINE]Génère du [ICON_TOURISM] Tourisme à la découverte de l'Aviation.[NEWLINE][NEWLINE]Doit être placé sur une case de côte ou de lac adjacente à une ressource maritime.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un kampung, exclusif à l'Indonésie.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1 et [ICON_HOUSING] Habitations +1.[NEWLINE][ICON_FOOD] Nourriture +1 et [ICON_FAITH] Foi +1 pour chaque bateau de pêche adjacent. [ICON_PRODUCTION] Production +1 à Génie Civil.[NEWLINE]Génère du [ICON_TOURISM] Tourisme à la découverte de l'Aviation.[NEWLINE][NEWLINE]Doit être placé sur une case de côte ou de lac adjacente à une ressource maritime.</Text>
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_UNIT_INDONESIAN_JONG_DESCRIPTION" Language="fr_FR">
@@ -786,15 +795,21 @@
 		</Replace>
 		<!-- = leader ability (Mvemba a Nzinga) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_RELIGIOUS_CONVERT_DESCRIPTION" Language="fr_FR">
-			<Text>Ne peut ni construire des Lieux saints, ni recruter de [ICON_GREATPROPHET] Prophète Illustre, ni fonder de [ICON_RELIGION] religion. Reçoit un Apôtre de la religion dominante de la ville lorsqu'il construit un Mbanza ou une Place du théâtre.[NEWLINE][NEWLINE]Vous obtenez une [ICON_GREATWORK_RELIC] relique gratuite à chaque fois que vous achevez un bâtiment de la Place de la gouvernance. [ICON_FOOD] Nourriture +2, [ICON_PRODUCTION] Production +2, [ICON_GOLD] Or +4 et [ICON_FAITH] Foi +1 pour les [ICON_GREATWORK_RELIC] reliques.[NEWLINE][NEWLINE]Les unités militaires de Mvemba a Nzinga se déplacent librement dans les bois et les forêts tropicales.</Text>
+			<Text>Ne peut ni construire des Lieux saints, ni recruter de [ICON_GREATPROPHET] Prophète Illustre, ni fonder de [ICON_RELIGION] religion. Reçoit un Apôtre de la religion dominante de la ville lorsqu'il construit un Mbanza ou une Place du théâtre.[NEWLINE][ICON_GOLD] Or +1 et [ICON_CULTURE] Culture +0.2 par [ICON_CITIZEN] Citoyens convertis dans vos villes.[NEWLINE][NEWLINE]Vous obtenez une [ICON_GREATWORK_RELIC] relique gratuite à chaque fois que vous achevez un bâtiment de la Place de la gouvernance. [ICON_FOOD] Nourriture +2, [ICON_PRODUCTION] Production +2, [ICON_GOLD] Or +4 et [ICON_FAITH] Foi +1 pour les [ICON_GREATWORK_RELIC] reliques.[NEWLINE][NEWLINE]Les unités militaires de Mvemba a Nzinga se déplacent librement dans les bois et les forêts tropicales.</Text>
 		</Replace>
 		<Row Tag="LOC_BBG_IGNORE_WOODS_ABILITY_DESCRIPTION" Language="fr_FR">
 			<Text>Pas de pénalité de [ICON_MOVEMENT] PM dans les bois et forêts tropicales.</Text>
 		</Row>
 		<!-- = leader ability (Nzinga Mbande) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_NZINGA_MBANDE_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_GOLD] Or +10% et [ICON_CULTURE] Culture +10% dans les villes avec un Mbanza (non cumulable). Les Mbanza donnent un bonus de proximité majeur aux Plateformes commerciales et aux Places du théâtre.[NEWLINE][NEWLINE]Les archéologues sont 50% moins chers à produire et acheter. </Text>
+			<Text>[ICON_GOLD] Or +10% et [ICON_CULTURE] Culture +10% dans les villes avec un Mbanza (non cumulable). Les Mbanza donnent un bonus de proximité majeur aux Plateformes commerciales et aux Places du théâtre.[NEWLINE][NEWLINE]Les archéologues sont 50% moins chers à produire et acheter.[NEWLINE][NEWLINE]Les unités civiles de Mbandi se déplacent librement dans les bois et les forêts tropicales.</Text>
 		</Replace>
+		<Row Tag="BBG_LOC_MBANDE_COMMERCIAL_MBANZA" Language="fr_FR">
+			<Text>[ICON_GOLD] Or +{1_num} de la part des Mbanza adjacents.</Text>
+		</Row>
+		<Row Tag="BBG_LOC_MBANDE_THEATRE_MBANZA" Language="fr_FR">
+			<Text>[ICON_CULTURE] Culture +{1_num} de la part des Mbanza adjacents.</Text>
+		</Row>
 		<!-- = unique district = -->
 		<Replace Tag="LOC_DISTRICT_MBANZA_DESCRIPTION" Language="fr_FR">
 			<Text>Exclusif au Kongo, ce quartier remplace le Quartier résidentiel.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +2, [ICON_GOLD] Or +4 et [ICON_HOUSING] Habitations +5, quel que soit l'Attrait.[NEWLINE][NEWLINE]Ne peut être construit que sur une case de bois ou de forêt tropicale. </Text>
@@ -853,10 +868,10 @@
 		<!-- == MACEDON - MACÉDOINE == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_HELLENISTIC_FUSION_DESCRIPTION" Language="fr_FR">
-			<Text>À partir de la Philosophie Politique, tous les [ICON_GOVERNMENT] gouvernements ont un emplacement de doctrine Militaire supplémentaire.[NEWLINE][NEWLINE]Vous recevez une amélioration pour chaque ville capturée : [ICON_PRODUCTION] Production +20% dans toutes vos villes pendant 10 [ICON_TURN] tours, un [ICON_TECHBOOSTED] Eurêka ! pour chaque Campement ou Campus de la ville conquise, et une [ICON_CIVICBOOSTED] Inspiration pour chaque Place du théâtre ou Lieu saint.</Text>
+			<Text>Vous recevez une amélioration pour chaque ville capturée : [ICON_PRODUCTION] Production +20% dans toutes vos villes pendant 10 [ICON_TURN] tours, un [ICON_TECHBOOSTED] Eurêka ! pour chaque Campement ou Campus de la ville conquise, et une [ICON_CIVICBOOSTED] Inspiration pour chaque Place du théâtre ou Lieu saint.</Text>
 		</Replace>
 		<Replace Tag="LOC_TRAIT_LEADER_HELLENISTIC_FUSION_EXPANSION1_DESCRIPTION" Language="fr_FR">
-			<Text>À partir de la Philosophie Politique, tous les [ICON_GOVERNMENT] gouvernements ont un emplacement de doctrine Militaire supplémentaire.[NEWLINE][NEWLINE]Vous recevez une amélioration pour chaque ville capturée : [ICON_PRODUCTION] Production +20% dans toutes vos villes pendant 10 [ICON_TURN] tours, un [ICON_TECHBOOSTED] Eurêka ! pour chaque Campement ou Campus de la ville conquise, et une [ICON_CIVICBOOSTED] Inspiration pour chaque Place du théâtre ou Lieu saint.</Text>
+			<Text>Vous recevez une amélioration pour chaque ville capturée : [ICON_PRODUCTION] Production +20% dans toutes vos villes pendant 10 [ICON_TURN] tours, un [ICON_TECHBOOSTED] Eurêka ! pour chaque Campement ou Campus de la ville conquise, et une [ICON_CIVICBOOSTED] Inspiration pour chaque Place du théâtre ou Lieu saint.</Text>
 		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_TO_WORLDS_END_DESCRIPTION" Language="fr_FR">
@@ -884,7 +899,7 @@
 		<!-- == MALI == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_MALI_GOLD_DESERT_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_FAITH] Foi +1 pour les Centres-villes pour chaque case de désert adjacentes. [ICON_FOOD] Nourriture +2 pour les Centre-villes si la ville possède au moins deux cases de désert.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production -20% pour toutes les villes.[NEWLINE][ICON_PRODUCTION] Production -1 et [ICON_GOLD] Or +2 pour les mines (passe à [ICON_GOLD] Or +4 à Banques).[NEWLINE][NEWLINE]Vous pouvez acheter les bâtiments des Sugubas avec de la [ICON_FAITH] Foi. Coût d'achat de cases de désert réduit de 50%.[NEWLINE][NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1 pour les cases de désert dans votre territoire.</Text>
+			<Text>[ICON_FAITH] Foi +1 pour les Centres-villes pour chaque case de désert adjacentes. [ICON_FOOD] Nourriture +2 pour les Centre-villes si la ville possède au moins deux cases de désert.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production -15% pour toutes les villes.[NEWLINE][ICON_PRODUCTION] Production -1 et [ICON_GOLD] Or +2 pour les mines (passe à [ICON_GOLD] Or +4 à Banques).[NEWLINE][NEWLINE]Vous pouvez acheter les bâtiments des Sugubas avec de la [ICON_FAITH] Foi. Coût d'achat de cases de désert réduit de 50%.[NEWLINE][NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1 pour les cases de désert dans votre territoire.</Text>
 		</Replace>
 		<!-- = leader ability (Mansa Moussa) = -->
 		<Replace Tag="LOC_TRAIT_LEADER_SAHEL_MERCHANTS_DESCRIPTION" Language="fr_FR">
@@ -935,7 +950,7 @@
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_MAORI_TOA_DESCRIPTION" Language="fr_FR">
-			<Text>Exclusive aux Maoris, cette unité classique de combat rapproché remplace le Spadassin. [ICON_STRENGTH] Puissance de bse +2. Ne nécessite pas de [ICON_RESOURCE_IRON] Fer. Les unités ennemies adjacentes reçoivent -5 [ICON_STRENGTH] Puissance de combat. Peut constuire un Pā (1 [ICON_CHARGES] charge).</Text>
+			<Text>Exclusive aux Maoris, cette unité classique de combat rapproché remplace le Spadassin. [ICON_STRENGTH] Puissance de base +2. Ne nécessite pas de [ICON_RESOURCE_IRON] Fer. Les unités ennemies adjacentes reçoivent -5 [ICON_STRENGTH] Puissance de combat. Peut constuire un Pā (1 [ICON_CHARGES] charge).</Text>
 		</Replace>
 
 		<!-- == MAPUCHE == -->
@@ -955,7 +970,7 @@
 		</Row>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_CHEMAMULL_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un chemamull, exclusif aux Mapuches.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1.[NEWLINE][ICON_PRODUCTION] Production +1 à Fonction Publique. Fournit une quantité de [ICON_CULTURE] Culture correspondant à 75% de l'Attrait de la case. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte.[NEWLINE][NEWLINE]Ne peut être posé que sur une case d'Attrait époustouflant.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un chemamull, exclusif aux Mapuches.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1.[NEWLINE][ICON_PRODUCTION] Production +1 à Fonction Publique. Fournit une quantité de [ICON_CULTURE] Culture correspondant à 75% de l'Attrait de la case. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte.[NEWLINE][NEWLINE]Ne peut être posé que sur une case d'Attrait époustouflant.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_MAPUCHE_MALON_RAIDER_DESCRIPTION" Language="fr_FR">
@@ -964,7 +979,7 @@
 		<Replace Tag="LOC_ABILITY_MAPUCHE_MALON_RAIDER_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_MOVEMENT] PM +1.</Text>
 		</Replace>
-		
+
 		<!-- == MAYA == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_MAYAB_DESCRIPTION" Language="fr_FR">
@@ -1000,7 +1015,7 @@
 		</Replace>
 		<!-- = unique building = -->
 		<Replace Tag="LOC_BUILDING_ORDU_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>Exclusif à la Mongolie, ce bâtiment remplace l'écurie. [ICON_MOVEMENT] PM +1 pour les unités de cavalerie et de siège formées dans cette ville. Expérience au combat +25 % pour toutes les unités de cavalerie formées dans cette ville.[NEWLINE]Réserve de ressources stratégiques +10 (en vitesse normale).[NEWLINE][NEWLINE]Construction impossible dans un campement possédant déjà une caserne.</Text>
+			<Text>Exclusif à la Mongolie, ce bâtiment remplace l'écurie. [ICON_MOVEMENT] PM +1 pour les unités de cavalerie formées dans cette ville. Expérience au combat +25 % pour toutes les unités de cavalerie formées dans cette ville.[NEWLINE]Réserve de ressources stratégiques +10 (en vitesse normale).[NEWLINE][NEWLINE]Construction impossible dans un campement possédant déjà une caserne.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_MONGOLIAN_KESHIG_DESCRIPTION" Language="fr_FR">
@@ -1053,7 +1068,7 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_PYRAMID_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une pyramide nubienne, exclusive à la Nubie. [NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1 et [ICON_FAITH] Foi +2.[NEWLINE][NEWLINE]Les [ICON_DISTRICT] quartiers adjacents octroient des rendements supplémentaires :[NEWLINE] • [ICON_FOOD] Nourriture +2 si adjacente à un Centre-ville.[NEWLINE] • [ICON_PRODUCTION] Production +2 par Zone industrielle adjacente.[NEWLINE] • [ICON_GOLD] Or +2 par Plateforme commerciale et Port adjacent.[NEWLINE] • [ICON_SCIENCE] Science +2 par Campus adjacent.[NEWLINE] • [ICON_CULTURE] Culture +2 par Place du théâtre adjacente.[NEWLINE] • [ICON_FAITH] Foi +2 par Lieu saint adjacent.[NEWLINE][NEWLINE]Doit être construit sur une plaine plate, une prairie plate, une plaine inondable ou un désert. Deux pyramides nubiennes ne peuvent pas être adjacentes.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une pyramide nubienne, exclusive à la Nubie. [NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1 et [ICON_FAITH] Foi +2.[NEWLINE][NEWLINE]Les [ICON_DISTRICT] quartiers adjacents octroient des rendements supplémentaires :[NEWLINE] • [ICON_FOOD] Nourriture +2 si adjacente à un Centre-ville.[NEWLINE] • [ICON_PRODUCTION] Production +2 par Zone industrielle adjacente.[NEWLINE] • [ICON_GOLD] Or +2 par Plateforme commerciale et Port adjacent.[NEWLINE] • [ICON_SCIENCE] Science +2 par Campus adjacent.[NEWLINE] • [ICON_CULTURE] Culture +2 par Place du théâtre adjacente.[NEWLINE] • [ICON_FAITH] Foi +2 par Lieu saint adjacent.[NEWLINE][NEWLINE]Doit être construit sur une plaine plate, une prairie plate, une plaine inondable ou un désert. Deux pyramides nubiennes ne peuvent pas être adjacentes.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_NUBIAN_PITATI_DESCRIPTION" Language="fr_FR">
@@ -1071,7 +1086,7 @@
 		</Replace>
 		<!-- = unique building = -->
 		<Replace Tag="LOC_BUILDING_GRAND_BAZAAR_DESCRIPTION" Language="fr_FR">
-			<Text>Exclusif aux Ottomans, ce bâtiment remplace la banque. Permet de créer une [ICON_TRADEROUTE] route commerciale supplémentaire.[NEWLINE] Octroie un [ICON_GOVERNOR] Titre de gouverneur quand vous achevez votre premier grand bazar.[NEWLINE]Accumulez une ressource stratégique supplémentaire pour chaque type de ressource stratégique aménagée dans cette ville. [ICON_AMENITIES] Activités +1 pour chaque ressource de luxe aménagée dans cette ville.[NEWLINE][ICON_GOLD] Or +2 pour les [ICON_TRADEROUTE] routes commerciales à l'origine de cette ville.[NEWLINE][ICON_GOLD] Or +1 pour les [ICON_TRADEROUTE] routes commerciales à destination de cette ville.</Text>
+			<Text>Exclusif aux Ottomans, ce bâtiment remplace la banque. Permet de créer une [ICON_TRADEROUTE] route commerciale supplémentaire.[NEWLINE]Octroie un [ICON_GOVERNOR] Titre de gouverneur quand vous achevez votre premier grand bazar.[NEWLINE]Accumulez une ressource stratégique supplémentaire pour chaque type de ressource stratégique aménagée dans cette ville. [ICON_AMENITIES] Activités +1 pour chaque ressource de luxe aménagée dans cette ville.[NEWLINE][ICON_GOLD] Or +2 pour les [ICON_TRADEROUTE] routes commerciales à l'origine de cette ville.[NEWLINE][ICON_GOLD] Or +1 pour les [ICON_TRADEROUTE] routes commerciales à destination de cette ville.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_SULEIMAN_JANISSARY_DESCRIPTION" Language="fr_FR">
@@ -1084,7 +1099,7 @@
 		<Replace Tag="LOC_ABILITY_CORSAIR_DESCRIPTION" Language="fr_FR">
 			<Text>Les assauts côtiers ne coûtent pas de [ICON_MOVEMENT] PM et peut naviguer sur les cases d'océan sans avoir recherché la Cartographie.</Text>
 		</Replace>
-		
+
 		<!-- == PERSIA - PERSE == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_SATRAPIES_DESCRIPTION" Language="fr_FR">
@@ -1113,13 +1128,13 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_PAIRIDAEZA_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un pairidaeza, exclusif à la Perse.[NEWLINE][NEWLINE][ICON_GOLD] Or +2, [ICON_CULTURE] Culture +1 et [ICON_HOUSING] Habitations +1.[NEWLINE][ICON_GOLD] Or +1 pour chaque Ce	ntre-ville, Zone industrielle, Port et Plateforme commerciale adjacent. [ICON_CULTURE] Culture +1 pour chaque Centre-ville, Campus, Place du théâtre et Lieu saint adjacent. [ICON_CULTURE] Culture +1 à Service diplomatique. Attrait +1 pour les cases adjacentes.[NEWLINE]Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture après la découverte de l'Aviation.[NEWLINE][NEWLINE]Construction impossible sur une case de neige, de toundra, de colline enneigée ou de colline de toundra, ou adjacent à un autre pairidaeza.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un pairidaeza, exclusif à la Perse.[NEWLINE][NEWLINE][ICON_GOLD] Or +2, [ICON_CULTURE] Culture +1 et [ICON_HOUSING] Habitations +1.[NEWLINE][ICON_GOLD] Or +1 pour chaque Ce	ntre-ville, Zone industrielle, Port et Plateforme commerciale adjacent. [ICON_CULTURE] Culture +1 pour chaque Centre-ville, Campus, Place du théâtre et Lieu saint adjacent. [ICON_CULTURE] Culture +1 à Service diplomatique. Attrait +1 pour les cases adjacentes.[NEWLINE]Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture après la découverte de l'Aviation.[NEWLINE][NEWLINE]Construction impossible sur une case de neige, de toundra, de colline enneigée ou de colline de toundra, ou adjacent à un autre pairidaeza.</Text>
 		</Replace>
 
 		<!-- == PHOENICIA - PHÉNICIE == -->
 		<!-- = civilization ability = -->
 		<Replace Tag="LOC_TRAIT_CIVILIZATION_MEDITERRANEAN_COLONIES_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_MOVEMENT] PM +2 et Champ de vision +2 pour les Colons embarqués. L'embarquement et le débarquement des colons de demande pas de [ICON_MOVEMENT] PM supplémentaire.[NEWLINE][NEWLINE]Les villes côtières fondées par la Phénicie et situées sur le même continent que la [ICON_CAPITAL] Capitale phénicienne sont loyales à 100%.[NEWLINE]Commencez la partie avec un [ICON_TECHBOOSTED] Eurêka pour l'Écriture.</Text>
+			<Text>[ICON_MOVEMENT] PM +2 et Champ de vision +2 pour les Colons embarqués. L'embarquement et le débarquement des Colons ne demande pas de [ICON_MOVEMENT] PM supplémentaire.[NEWLINE][NEWLINE]Les villes côtières fondées par la Phénicie et situées sur le même continent que la [ICON_CAPITAL] Capitale phénicienne sont loyales à 100%.[NEWLINE]Commencez la partie avec un [ICON_TECHBOOSTED] Eurêka pour l'Écriture.</Text>
 		</Replace>
 		<!-- = leader ability = -->
 		<Replace Tag="LOC_TRAIT_LEADER_FOUNDER_CARTHAGE_DESCRIPTION" Language="fr_FR">
@@ -1163,7 +1178,7 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_FEITORIA_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence Nau permettant de construire une feitoria, exclusif au Portugal.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1 et [ICON_GOLD] Or +4.[NEWLINE][ICON_PRODUCTION] Production +1 et [ICON_GOLD] Or +2 pour les [ICON_TRADEROUTE] routes commerciales entre cette ville et le Portugal.[NEWLINE][NEWLINE]Ne peut être construite que sur une case côtière ou de lac, adjacente à une ressource de luxe ou bonus sur le territoire d'une autre civilisation ou d'une Cité-état. Les feitorias ne peuvent ni être adjacentes entre elles, ni supprimées.</Text>
+			<Text>Débloque la compétence de Nau permettant de construire une feitoria, exclusif au Portugal.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1 et [ICON_GOLD] Or +4.[NEWLINE][ICON_PRODUCTION] Production +1 et [ICON_GOLD] Or +2 pour les [ICON_TRADEROUTE] routes commerciales entre cette ville et le Portugal.[NEWLINE][NEWLINE]Ne peut être construite que sur une case côtière ou de lac, adjacente à une ressource de luxe ou bonus sur le territoire d'une autre civilisation ou d'une Cité-état. Les feitorias ne peuvent ni être adjacentes entre elles, ni supprimées.</Text>
 		</Replace>
 		<!-- = unique building = -->
 		<Replace Tag="LOC_BUILDING_NAVIGATION_SCHOOL_DESCRIPTION" Language="fr_FR">
@@ -1234,7 +1249,7 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_GOLF_COURSE_XP2_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un terrain de golf, exclusif à l'Écosse.[NEWLINE][NEWLINE][ICON_GOLD] Or +2, [ICON_CULTURE] Culture +1 et [ICON_AMENITIES] Activités +1.[NEWLINE][ICON_GOLD] Or +1 et [ICON_CULTURE] Culture +1 si adjacent à un Centre-ville. [ICON_GOLD] Or +1 et [ICON_CULTURE] Culture +1 aux Lumières. [ICON_CULTURE] Culture +1 et [ICON_AMENITIES] Activités +1 si adjacent à un Complexe de loisirs. [ICON_AMENITIES] Activités +1 aux Guildes. [ICON_HOUSING] Habitations +1 à Mondialisation. Attrait +1 pour les cases adjacentes.[NEWLINE][NEWLINE][NEWLINE]Ne peut pas être construit sur un désert ou sur une colline désertique. Un par ville. Les cases contenant un terrain de golf ne peuvent pas être attribuées à une autre ville.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un terrain de golf, exclusif à l'Écosse.[NEWLINE][NEWLINE][ICON_GOLD] Or +2, [ICON_CULTURE] Culture +1 et [ICON_AMENITIES] Activités +1.[NEWLINE][ICON_GOLD] Or +1 et [ICON_CULTURE] Culture +1 si adjacent à un Centre-ville. [ICON_GOLD] Or +1 et [ICON_CULTURE] Culture +1 aux Lumières. [ICON_CULTURE] Culture +1 et [ICON_AMENITIES] Activités +1 si adjacent à un Complexe de loisirs. [ICON_AMENITIES] Activités +1 aux Guildes. [ICON_HOUSING] Habitations +1 à Mondialisation. Attrait +1 pour les cases adjacentes.[NEWLINE][NEWLINE][NEWLINE]Ne peut pas être construit sur un désert ou sur une colline désertique. Un par ville. Les cases contenant un terrain de golf ne peuvent pas être attribuées à une autre ville.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_SCOTTISH_HIGHLANDER_DESCRIPTION" Language="fr_FR">
@@ -1252,7 +1267,7 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_KURGAN_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une kourgane, exclusive à la Scythie.[NEWLINE][NEWLINE][ICON_GOLD] Or +3 et [ICON_FAITH] Foi +2.[NEWLINE][ICON_PRODUCTION] Production +1 et [ICON_FAITH] Foi +1 (porté à [ICON_FAITH] Foi +2 à Étriers) pour chaque pâturage adjacent. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_FAITH] Foi après la découverte de l'Aviation.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une kourgane, exclusive à la Scythie.[NEWLINE][NEWLINE][ICON_GOLD] Or +3 et [ICON_FAITH] Foi +2.[NEWLINE][ICON_PRODUCTION] Production +1 et [ICON_FAITH] Foi +1 (porté à [ICON_FAITH] Foi +2 à Étriers) pour chaque pâturage adjacent. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_FAITH] Foi après la découverte de l'Aviation.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_SCYTHIAN_HORSE_ARCHER_DESCRIPTION" Language="fr_FR">
@@ -1270,7 +1285,7 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_MISSION_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une mission, exclusive à l'Espagne.[NEWLINE][NEWLINE][ICON_FAITH] Foi +2.[NEWLINE][ICON_PRODUCTION] Production +1, [ICON_FAITH] Foi +1 et [ICON_HOUSING] Habitations +1 si bâtie à 8 cases ou plus de votre [ICON_CAPITAL] Capitale. [ICON_SCIENCE] Science +1 pour chaque Campus et Lieu saint adjacent. [ICON_SCIENCE] Science +2 aux Lumières.[NEWLINE][NEWLINE]Deux missions ne peuvent pas être adjacentes.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une mission, exclusive à l'Espagne.[NEWLINE][NEWLINE][ICON_FAITH] Foi +2.[NEWLINE][ICON_PRODUCTION] Production +1, [ICON_FAITH] Foi +1 et [ICON_HOUSING] Habitations +1 si bâtie à 8 cases ou plus de votre [ICON_CAPITAL] Capitale. [ICON_SCIENCE] Science +1 pour chaque Campus et Lieu saint adjacent. [ICON_SCIENCE] Science +2 aux Lumières.[NEWLINE][NEWLINE]Deux missions ne peuvent pas être adjacentes.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_SPANISH_CONQUISTADOR_DESCRIPTION" Language="fr_FR">
@@ -1312,7 +1327,7 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_ZIGGURAT_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une ziggurat, exclusive au Sumer.[NEWLINE][NEWLINE][ICON_SCIENCE] Science +2 et [ICON_HOUSING] Habitations +1.[NEWLINE][ICON_CULTURE] Culture +1 si adjacente à une rivière. [ICON_FAITH] Foi +1 par [ICON_DISTRICT] quartier adjacent et toutes les deux fermes adjacentes.[NEWLINE][NEWLINE]Construction impossible sur une colline ou à côté d'une autre Ziggurat.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une ziggurat, exclusive au Sumer.[NEWLINE][NEWLINE][ICON_SCIENCE] Science +2 et [ICON_HOUSING] Habitations +1.[NEWLINE][ICON_CULTURE] Culture +1 si adjacente à une rivière. [ICON_FAITH] Foi +1 par [ICON_DISTRICT] quartier adjacent et toutes les deux fermes adjacentes au Premier Empire.[NEWLINE][NEWLINE]Construction impossible sur une colline ou à côté d'une autre Ziggurat.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_SUMERIAN_WAR_CART_DESCRIPTION" Language="fr_FR">
@@ -1340,7 +1355,7 @@
 		</Replace>
 		<!-- = unique improvement = -->
 		<Replace Tag="LOC_IMPROVEMENT_OPEN_AIR_MUSEUM_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un musée en plein air, exclusif à la Suède.[NEWLINE][NEWLINE]Loyauté +2 par tour dans la ville.[NEWLINE][ICON_CULTURE] Culture +2 et [ICON_TOURISM] Tourisme +2 pour chaque type de terrain (neige, toundra, désert, plaine ou prairie) sur lequel au moins une ville suédoise est construite.[NEWLINE][NEWLINE]Limité à un par ville. Les cases contenant un musée en plein air ne peuvent pas être attribuées à une autre ville.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un musée en plein air, exclusif à la Suède.[NEWLINE][NEWLINE]Loyauté +2 par tour dans la ville.[NEWLINE][ICON_CULTURE] Culture +2 et [ICON_TOURISM] Tourisme +2 pour chaque type de terrain (neige, toundra, désert, plaine ou prairie) sur lequel au moins une ville suédoise est construite.[NEWLINE][NEWLINE]Limité à un par ville. Les cases contenant un musée en plein air ne peuvent pas être attribuées à une autre ville.</Text>
 		</Replace>
 		<!-- = unique unit = -->
 		<Replace Tag="LOC_UNIT_SWEDEN_CAROLEAN_DESCRIPTION" Language="fr_FR">
@@ -1408,9 +1423,6 @@
 	    <Replace Tag="LOC_PROMOTION_MONK_COBRA_STRIKE_DESCRIPTION" Language="fr_FR">
       		<Text>[ICON_STRENGTH] Puissance de combat +7.</Text>
     	</Replace>
-		<Replace Tag="LOC_UNIT_LAHORE_NIHANG_DESCRIPTION" Language="fr_FR">
-			<Text>Unité exclusive à la Cité-état de Lahore avec un arbre de compétences spécifique. Peut être achetée avec de la [ICON_FAITH] Foi. [ICON_STRENGTH] Puissance de combat +15 si vous possédez une caserne. De même si vous possédez une armurerie ou une école militaire. Reçoit les bonus des [ICON_GREATGENERAL] Généraux illustres de toutes les ères.</Text>
-		</Replace>
 		<Replace Tag="LOC_UNIT_TRADER_DESCRIPTION" Language="fr_FR"> <!-- embarkation tip -->
 			<Text>Crée une route commerciale entre 2 villes. Crée automatiquement une route sur son passage. Peut embarquer une fois la Navigation Astronomique ou la Construction Navale découverte.</Text>
 		</Replace>
@@ -1473,7 +1485,7 @@
             <Text>[ICON_BOMBARD] Puissance de bombardement +10 en attaquant des unités navales.</Text>
         </Replace>
         <Replace Tag="LOC_PROMOTION_BATTLECRY_DESCRIPTION" Language="fr_FR">
-            <Text>[ICON_STRENGTH] Puissance de combat +7 en attaquant des unités de classe combat rapproché, anti-cavalerie, combat à distance ou reconnaissance.</Text>
+            <Text>[ICON_STRENGTH] Puissance de combat +7 en attaquant des unités de combat rapproché, d'anti-cavalerie, de combat à distance ou de reconnaissance.</Text>
         </Replace>
 		<Replace Tag="LOC_PROMOTION_MONK_EXPLODING_PALMS_DESCRIPTION" Language="fr_FR">
       		<Text>[ICON_STRENGTH] Puissance de combat +5.</Text>
@@ -1488,7 +1500,7 @@
 			<Text>[ICON_RANGED] Puissance d'attaque à distance +7.</Text>
 		</Replace>
 		<Replace Tag="LOC_PROMOTION_MONK_DISCIPLES_DESCRIPTION" Language="fr_FR">
-			<Text>Lors d'une victoire militaire, propage la religion dans un rayon de 5 cases.</Text>
+			<Text>Lors d'une victoire militaire, propage la [ICON_RELIGION] religion dans un rayon de 5 cases.</Text>
 		</Replace>
 		<Replace Tag="LOC_PROMOTION_GARRISON_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_STRENGTH] Puissance de combat +10 si l'unité occupe un quartier défendable ou un fort.</Text>
@@ -1579,7 +1591,7 @@
 			<Text>[ICON_CULTURE] Culture +1 par tour pour chaque [ICON_CITIZEN] Citoyen dans la ville.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_CARDINAL_CITADEL_OF_GOD_DESCRIPTION" Language="fr_FR">
-		  <Text>La ville ignore la pression des religions qui n'ont pas été fondées par le joueur du [ICON_GOVERNOR] gouverneur. Octroie 25 % du coût de la construction des bâtiments en [ICON_FAITH] Foi une fois ceux-ci achevés.</Text>
+			<Text>La ville ignore la pression des religions qui n'ont pas été fondées par le joueur du [ICON_GOVERNOR] gouverneur. Octroie 25 % du coût de la construction des bâtiments en [ICON_FAITH] Foi une fois ceux-ci achevés.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_CARDINAL_DIVINE_ARCHITECT_DESCRIPTION" Language="fr_FR">
 			<Text>Permet à la ville d'acheter des quartiers avec de la [ICON_FAITH] Foi.</Text>
@@ -1593,27 +1605,27 @@
 
 		<!-- == Magnus == -->
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_RESOURCE_MANAGER_GROUNDBREAKER_DESCRIPTION" Language="fr_FR">
-		  <Text>Rendements +50% pour les cases récoltées et le retrait de caractéristiques de terrain dans la ville.</Text>
+			<Text>Rendements +50% pour les cases récoltées et le retrait de caractéristiques de terrain dans la ville.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_RESOURCE_MANAGER_SURPLUS_LOGISTICS_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_FOOD] Croissance de la ville +20%. Vos [ICON_TRADEROUTE] routes commerciales s'y terminant fournissent +2 [ICON_FOOD] Nourriture à la ville d'origine. Les colons formés dans la ville ont 1 [ICON_MOVEMENT] PM supplémentaire.</Text>
+			<Text>[ICON_FOOD] Croissance de la ville +20%. Vos [ICON_TRADEROUTE] routes commerciales s'y terminant fournissent +2 [ICON_PRODUCTION] Production à la ville d'origine. Les Colons formés dans la ville ont 1 [ICON_MOVEMENT] PM supplémentaire.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_RESOURCE_MANAGER_EXPEDITION_DESCRIPTION" Language="fr_FR">
-			<Text>Vos [ICON_TRADEROUTE] routes commerciales se terminant dans cette ville fournissent +2 [ICON_PRODUCTION] Production à la ville d'origine. La ville ne perd plus de [ICON_CITIZEN] Citoyen lors de la formation de colons.</Text>
+			<Text>Vos [ICON_TRADEROUTE] routes commerciales se terminant dans cette ville fournissent +2 [ICON_FOOD] Nourriture à la ville d'origine. La ville ne perd plus de [ICON_CITIZEN] Citoyen lors de la formation de Colons.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_RESOURCE_MANAGER_INDUSTRIALIST_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_PRODUCTION] Production +4 et [ICON_POWER] Électricité +4 pour la centrale électrique de la ville.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_RESOURCE_MANAGER_VERTICAL_INTEGRATION_DESCRIPTION" Language="fr_FR">
-		  <Text>Cette ville reçoit de la [ICON_PRODUCTION] Production pour chaque bâtiment de Zone industrielle recevant des bonus régionaux à proximité, et pas seulement le premier.</Text>
+			<Text>Cette ville reçoit de la [ICON_PRODUCTION] Production pour chaque bâtiment de Zone industrielle recevant des bonus régionaux à proximité, et pas seulement le premier.</Text>
 		</Replace>
 		 <Replace Tag="LOC_GOVERNOR_PROMOTION_EDUCATOR_ARMS_RACE_PROPONENT_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +30 % pour tous les projets d'armement nucléaire de la ville.</Text>
+			<Text>[ICON_PRODUCTION] Production +30% pour tous les projets d'armement nucléaire de la ville.</Text>
 		</Replace>
 		
 		<!-- == Liang == -->
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_BUILDER_GUILDMASTER_DESCRIPTION" Language="fr_FR">
-			<Text>Les bâtisseurs formés dans la ville gagnent une [ICON_CHARGES] charge supplémentaire.</Text>
+			<Text>Les Bâtisseurs formés dans la ville gagnent une [ICON_CHARGES] charge supplémentaire.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_REINFORCED_INFRASTRUCTURE_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_PRODUCTION] Production +1 pour les plaines inondables et les sols volcaniques dans cette ville. Les aménagements, bâtiments et quartiers de cette ville ne peuvent pas être endommagés par les effets environnementaux.</Text>
@@ -1671,7 +1683,7 @@
 
 		<!-- == Reyna == -->
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_MERCHANT_LAND_ACQUISITION_DESCRIPTION" Language="fr_FR">
-			<Text>Acquisition de nouvelles cases plus rapide dans la ville. [ICON_GOLD] Or par tour +4 pour chaque [ICON_TRADEROUTE] route commerciale étrangère arrivant à ou passant par la ville. S'établit en 4 tours.</Text>
+			<Text>Acquisition de nouvelles cases plus rapide dans la ville. [ICON_GOLD] Or par tour +4 pour chaque [ICON_TRADEROUTE] route commerciale étrangère arrivant à ou passant par la ville.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_MERCHANT_HARBORMASTER_DESCRIPTION" Language="fr_FR">
 			<Text>Double le bonus de proximité de la Plateforme commerciale et/ou du Port de la ville.</Text>
@@ -1683,7 +1695,7 @@
 			<Text>[ICON_GOLD] Or +2 par tour pour chaque [ICON_CITIZEN] Citoyen dans la ville. Capacité de [ICON_TRADEROUTE] routes commerciales +1.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVERNOR_PROMOTION_MERCHANT_CONTRACTOR_DESCRIPTION" Language="fr_FR">
-			<Text>Permet à la ville d'acheter des [ICON_DISTRICT] quartiers avec de l'[ICON_GOLD] or.</Text>
+			<Text>Permet à la ville d'acheter des [ICON_DISTRICT] quartiers avec de [ICON_GOLD] l'Or.</Text>
 		</Replace>
 		<Row Tag="LOC_GOVERNOR_PROMOTION_MERCHANT_INVESTOR_NAME" Language="fr_FR">
 			<Text>Négociatrice</Text>
@@ -1716,10 +1728,10 @@
 			<Text>[ICON_FOOD] Nourriture +1 pour les ressources de [ICON_RESOURCE_CATTLE] Bétail, de [ICON_RESOURCE_RICE] Riz, de [ICON_RESOURCE_WHEAT] Blé et de [ICON_RESOURCE_MAIZE] Maïs.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_RELIGIOUS_SETTLEMENTS_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +20% pour les colons.[NEWLINE]Vos villes reçoivent 2 cases gratuites quand elles sont fondées et voient la vitesse d'expansion de leurs frontières augmenter de 50%.</Text>
+			<Text>[ICON_PRODUCTION] Production +20% pour les Colons.[NEWLINE]Vos villes reçoivent 2 cases gratuites quand elles sont fondées et voient la vitesse d'expansion de leurs frontières augmenter de 50%.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_RELIGIOUS_SETTLEMENTS_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +20% pour les colons.[NEWLINE]Vos villes reçoivent 2 cases gratuites quand elles sont fondées et voient la vitesse d'expansion de leurs frontières augmenter de 50%.</Text>
+			<Text>[ICON_PRODUCTION] Production +20% pour les Colons.[NEWLINE]Vos villes reçoivent 2 cases gratuites quand elles sont fondées et voient la vitesse d'expansion de leurs frontières augmenter de 50%.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_RIVER_GODDESS_DESCRIPTION" Language="fr_FR">
 			<Text>Bonus de proximité +1 pour les Lieux saints adjacents à une rivière. [ICON_AMENITIES] Activités +1 dans les villes possédant un Lieu saint adjacent à une rivière.</Text>
@@ -1822,7 +1834,7 @@
 			<Text>[ICON_SCIENCE] Science +1 par groupe de 3 fidèles de cette [ICON_RELIGION] religion dans d'autres civilisations.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_TITHE_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_GOLD] Or +2 pour chaque ville convertie à cette [ICON_RELIGION] religion.</Text>
+			<Text>[ICON_GOLD] Or +3 pour chaque ville convertie à cette [ICON_RELIGION] religion.</Text>
 		</Replace>
 		<Replace Tag="LOC_BELIEF_WORLD_CHURCH_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_CULTURE] Culture +1 par groupe de 3 fidèles de cette [ICON_RELIGION] religion dans d'autres civilisations.</Text>
@@ -1917,51 +1929,51 @@
 
 		<!-- === IMPROVEMENTS - AMÉNAGEMENTS === -->
 		<Replace Tag="LOC_IMPROVEMENT_FARM_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une ferme.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1 et [ICON_HOUSING] Habitations +0,5. [ICON_FOOD] Nourriture +1 toutes les 2 fermes adjacentes à la Fédoalité (+1 toutes les fermes adjacentes Pièces de Rechange). Ne peut être construite que sur une prairie ou une plaine.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une ferme.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1 et [ICON_HOUSING] Habitations +0,5. [ICON_FOOD] Nourriture +1 toutes les 2 fermes adjacentes à la Fédoalité (+1 toutes les fermes adjacentes Pièces de Rechange). Ne peut être construite que sur une prairie ou une plaine.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_MINE_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une mine.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1. [ICON_PRODUCTION] Production +1 à Apprentissage, Industrialisation et Matériaux Intelligents. Attrait -1 pour les cases adjacentes. Ne peut être construite que sur une colline ou une ressource valide.[NEWLINE][NEWLINE]Permet d'utiliser la ressource stratégique ou de luxe sur laquelle l'aménagement est construit.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une mine.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1. [ICON_PRODUCTION] Production +1 à Apprentissage, Industrialisation et Matériaux Intelligents. Attrait -1 pour les cases adjacentes. Ne peut être construite que sur une colline ou une ressource valide.[NEWLINE][NEWLINE]Permet d'utiliser la ressource stratégique ou de luxe sur laquelle l'aménagement est construit.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_LUMBER_MILL_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une scierie.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +2. [ICON_PRODUCTION] Production +1 à Ballistiques et à Matériaux Synthétiques. Ne peut être construite que sur une case de bois, ou une case de forêt tropicale une fois le Mercantilisme découvert.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une scierie.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +2. [ICON_PRODUCTION] Production +1 à Ballistiques et à Matériaux Synthétiques. Ne peut être construite que sur une case de bois, ou une case de forêt tropicale une fois le Mercantilisme découvert.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_FISHING_BOATS_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un bateau de pêche.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1, [ICON_PRODUCTION] Production +1 et [ICON_HOUSING] Habitations +0,5. [ICON_FOOD] Nourriture +1 à Matières Plastiques. [ICON_PRODUCTION] Production +1 à Colonialisme. [ICON_GOLD] Or +2 à la Cartographie. Ne peut être construit que sur une ressource valide.[NEWLINE][NEWLINE]Permet d'utiliser la ressource de luxe sur laquelle l'aménagement est construit.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un bateau de pêche.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1, [ICON_PRODUCTION] Production +1 et [ICON_HOUSING] Habitations +0,5. [ICON_FOOD] Nourriture +1 à Matières Plastiques. [ICON_PRODUCTION] Production +1 à Colonialisme. [ICON_GOLD] Or +2 à la Cartographie. Ne peut être construit que sur une ressource valide.[NEWLINE][NEWLINE]Permet d'utiliser la ressource de luxe sur laquelle l'aménagement est construit.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_PASTURE_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un pâturage.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1 et [ICON_HOUSING] Habitations +0,5. [ICON_FOOD] Nourriture +1 à Étriers et à Robotique. [ICON_PRODUCTION] Production +1 à Pièces de Rechange. Ne peut être construit que sur une ressource valide.[NEWLINE][NEWLINE]Permet d'utiliser la ressource stratégique sur laquelle l'aménagement est construit.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un pâturage.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1 et [ICON_HOUSING] Habitations +0,5. [ICON_FOOD] Nourriture +1 à Étriers et à Robotique. [ICON_PRODUCTION] Production +1 à Pièces de Rechange. Ne peut être construit que sur une ressource valide.[NEWLINE][NEWLINE]Permet d'utiliser la ressource stratégique sur laquelle l'aménagement est construit.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_QUARRY_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une carrière.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1. [ICON_PRODUCTION] Production +1 à Ingénierie Militaire, +2 à Fusées. Attrait pour les cases adjacentes -1. Ne peut être construite que sur une ressource valide.[NEWLINE][NEWLINE]Permet d'utiliser la ressource de luxe sur laquelle l'aménagement est construit.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une carrière.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1. [ICON_PRODUCTION] Production +1 à Ingénierie Militaire, +2 à Fusées. Attrait pour les cases adjacentes -1. Ne peut être construite que sur une ressource valide.[NEWLINE][NEWLINE]Permet d'utiliser la ressource de luxe sur laquelle l'aménagement est construit.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_PLANTATION_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une plantation.[NEWLINE][NEWLINE][ICON_GOLD] Or +2. [ICON_FOOD] Nourriture +1 à Féodalité et à Théorie Scientifique. [ICON_GOLD] Or +2 à Mondialisation.[NEWLINE][ICON_PRODUCTION] Production +1 si construite sur une case plate. Ne peut être construite que sur une ressource valide.[NEWLINE][NEWLINE]Permet d'utiliser la ressource de luxe sur laquelle l'aménagement est construit.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une plantation.[NEWLINE][NEWLINE][ICON_GOLD] Or +2. [ICON_FOOD] Nourriture +1 à Féodalité et à Théorie Scientifique. [ICON_GOLD] Or +2 à Mondialisation.[NEWLINE][ICON_PRODUCTION] Production +1 si construite sur une case plate. Ne peut être construite que sur une ressource valide.[NEWLINE][NEWLINE]Permet d'utiliser la ressource de luxe sur laquelle l'aménagement est construit.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_CAMP_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un camp.[NEWLINE][NEWLINE][ICON_GOLD] Or +2. [ICON_FOOD] Nourriture +1 et [ICON_PRODUCTION] Production +1 à Mercantilisme. [ICON_GOLD] Or +2 à Matériaux Synthétiques. Ne peut être construit que sur une ressource valide.[NEWLINE][NEWLINE]Permet d'utiliser la ressource sur laquelle l'aménagement est construit.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un camp.[NEWLINE][NEWLINE][ICON_GOLD] Or +2. [ICON_FOOD] Nourriture +1 et [ICON_PRODUCTION] Production +1 à Mercantilisme. [ICON_GOLD] Or +2 à Matériaux Synthétiques. Ne peut être construit que sur une ressource valide.[NEWLINE][NEWLINE]Permet d'utiliser la ressource sur laquelle l'aménagement est construit.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_OIL_WELL_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un puits de pétrole. [ICON_PRODUCTION] Production +2. [ICON_PRODUCTION] +1 à Systèmes Prédictifs. Attrait -1 pour les cases adjacentes. Ne peut être construit que sur une case terrestre contenant du [ICON_RESOURCE_OIL] pétrole, et permet ainsi de l'utiliser.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un puits de pétrole. [ICON_PRODUCTION] Production +2. [ICON_PRODUCTION] +1 à Systèmes Prédictifs. Attrait -1 pour les cases adjacentes. Ne peut être construit que sur une case terrestre contenant du [ICON_RESOURCE_OIL] pétrole, et permet ainsi de l'utiliser.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_OFFSHORE_OIL_RIG_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une plateforme pétrolière. [ICON_PRODUCTION] Production +2. [ICON_PRODUCTION] Production +1 à Systèmes Prédictifs. Attrait pour les cases adjacentes -1. Ne peut être construite que sur une case côtière ou lacustre contenant du [ICON_RESOURCE_OIL] pétrole, et permet ainsi de l'utiliser.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une plateforme pétrolière. [ICON_PRODUCTION] Production +2. [ICON_PRODUCTION] Production +1 à Systèmes Prédictifs. Attrait pour les cases adjacentes -1. Ne peut être construite que sur une case côtière ou lacustre contenant du [ICON_RESOURCE_OIL] pétrole, et permet ainsi de l'utiliser.</Text>
 		</Replace>		
 		<Replace Tag="LOC_IMPROVEMENT_FISHERY_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une aquaculture. [ICON_FOOD] Nourriture +1 et [ICON_HOUSING] Habitations +0,5. [ICON_FOOD] Nourriture +1 par ressource maritime adjacente. Ne peut être construite que sur la côte.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une aquaculture. [ICON_FOOD] Nourriture +1 et [ICON_HOUSING] Habitations +1. [ICON_FOOD] Nourriture +1 par ressource maritime adjacente. Ne peut être construite que sur la côte.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_BEACH_RESORT_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une station balnéaire.[NEWLINE][NEWLINE]Fournit une quantité de [ICON_TOURISM] Tourisme égale à 200% de l'Attrait de la case. Ne peut être construite que sur un désert côtier, une plaine côtière ou une prairie côtière. Attrait minimum : charmant.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une station balnéaire.[NEWLINE][NEWLINE]Fournit une quantité de [ICON_TOURISM] Tourisme égale à 200% de l'Attrait de la case. Ne peut être construite que sur un désert côtier, une plaine côtière ou une prairie côtière. Attrait minimum : charmant.</Text>
 		</Replace>
 		<!-- isnt codable
 		<Replace Tag="LOC_IMPROVEMENT_SKI_RESORT_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une station de sports d'hiver.[NEWLINE][NEWLINE]Fournit une quantité de [ICON_TOURISM] Tourisme égale à 150% de l'Attrait de la case. [ICON_AMENITIES] Activités +1. Ne peut être construit que sur une montagne. Ne peut pas être construite adjacente à une autre station de sports d'hiver.[NEWLINE]Ne peut pas être pillée, supprimée et exploitée.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une station de sports d'hiver.[NEWLINE][NEWLINE]Fournit une quantité de [ICON_TOURISM] Tourisme égale à 150% de l'Attrait de la case. [ICON_AMENITIES] Activités +1. Ne peut être construit que sur une montagne. Ne peut pas être construite adjacente à une autre station de sports d'hiver.[NEWLINE]Ne peut pas être pillée, supprimée et exploitée.</Text>
 		</Replace>
 		-->
 		<Replace Tag="LOC_IMPROVEMENT_GEOTHERMAL_PLANT_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une centrale géothermique.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +2 et [ICON_SCIENCE] Science +1. [ICON_POWER] Électricité +3 par tour. [ICON_PRODUCTION] Production +1, [ICON_SCIENCE] Science +1 et [ICON_POWER] Électricité +3 par tour à Matériaux Synthétiques. Doit être construit sur une fissure géothermique.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une centrale géothermique.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +2, [ICON_SCIENCE] Science +1 et [ICON_POWER] Électricité +3. [ICON_PRODUCTION] Production +1, [ICON_SCIENCE] Science +1 et [ICON_POWER] Électricité +3 à Matériaux Synthétiques. Doit être construit sur une fissure géothermique.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_FORT_DESCRIPTION" Language="fr_FR">
-			<Text>L'unité occupante gagne automatiquement 2 tours de retranchement et gagne +4 [ICON_STRENGTH] Puissance de combat en défense.</Text>
+			<Text>L'unité occupante gagne automatiquement 2 tours de retranchement, +1 Vision et gagne +4 [ICON_STRENGTH] Puissance de combat en défense.</Text>
 		</Replace>
 		<Replace Tag="LOC_IMPROVEMENT_AIRSTRIP_DESCRIPTION" Language="fr_FR">
 			<Text>Débloque la compétence d'ingénieur militaire permettant de construire une piste d'atterrissage.[NEWLINE][NEWLINE]Peut héberger 3 unités aériennes. Ne peut être construite que sur un terrain plat. Attrait pour les cases adjacentes -1.</Text>
@@ -2005,7 +2017,7 @@
       		<Text>Octroie un Espion gratuit et deux emplacement d'Espions. [ICON_PRODUCTION] Production +50% pour les Espions.[NEWLINE]Les opérations d'espionnage ont de plus grandes chances de réussir.[NEWLINE]Octroie un [ICON_GOVERNOR] Titre de gouverneur.</Text>
     	</Replace>
 		<Replace Tag="LOC_BUILDING_GOV_SCIENCE_DESCRIPTION" Language="fr_FR">
-			<Text>Les bâtisseurs et les ingénieurs militaires peuvent utiliser toutes leurs [ICON_CHARGES] charges pour accélérer des projets de [ICON_DISTRICT] quartier. Chaque [ICON_CHARGES] charge donne 2% du coût en [ICON_PRODUCTION] Production du projet. Une fois par ville et par tour.[NEWLINE]Octroie un [ICON_GOVERNOR] Titre de gouverneur.</Text>
+			<Text>Les Bâtisseurs et les ingénieurs militaires peuvent utiliser toutes leurs [ICON_CHARGES] charges pour accélérer des projets de [ICON_DISTRICT] quartier. Chaque [ICON_CHARGES] charge donne 2% du coût en [ICON_PRODUCTION] Production du projet. Une fois par ville et par tour.[NEWLINE]Octroie un [ICON_GOVERNOR] Titre de gouverneur.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_SEAPORT_DESCRIPTION" Language="fr_FR">
 			<Text>Expérience au combat +25% pour toutes les unités navales formées dans cette ville. Permet la formation immédiate de [ICON_CORPS] Flottes et [ICON_ARMY] d'Armadas. Coûts d'entraînement des [ICON_CORPS] Flottes et des [ICON_ARMY] Armadas -25%. [ICON_GOLD] Or +2 pour toutes les cases côtières de la ville.</Text>
@@ -2045,6 +2057,13 @@
 		</Replace>
 		<Replace Tag="LOC_BUILDING_STADIUM_EXPANSION1_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_AMENITIES] L'Activité bonus s'étend à chaque Centre-ville dans un rayon de 6 cases. Ce bonus ne s'applique qu'une seule fois par ville. [ICON_TOURISM] Tourisme +6 (+15 si alimenté en électricité).</Text>
+		</Replace>
+		
+		<Replace Tag="LOC_BUILDING_GROVE_DESCRIPTION" Language="fr_FR">
+			<Text>Les cases non aménagées adjacentes reçoivent des rendements selon leur Attrait :[NEWLINE] • [ICON_FOOD] Nourriture +1 et [ICON_FAITH] Foi +1 pour toutes les cases.[NEWLINE] • [ICON_FOOD] Nourriture +1, [ICON_CULTURE] Culture +1 et [ICON_FAITH] Foi +1 pour les cases d'Attrait charmant.[NEWLINE] • [ICON_FOOD] Nourriture +2, [ICON_CULTURE] Culture +2 et [ICON_FAITH] Foi +2 pour les cases d'Attrait époustouflant.</Text>
+		</Replace>
+		<Replace Tag="LOC_BUILDING_SANCTUARY_DESCRIPTION" Language="fr_FR">
+			<Text>Les cases non aménagées adjacentes reçoivent des rendements selon leur Attrait :[NEWLINE] • [ICON_GOLD] Or +1 et [ICON_SCIENCE] Science +1 pour toutes les cases.[NEWLINE] • [ICON_PRODUCTION] Production +1, [ICON_GOLD] Or +1 et [ICON_SCIENCE] Science +1 pour les cases d'Attrait charmant.[NEWLINE] • [ICON_PRODUCTION] Production +2, [ICON_GOLD] Or +2 et [ICON_SCIENCE] Science +2 pour les cases d'Attrait époustouflant.</Text>
 		</Replace>
 		
 
@@ -2189,7 +2208,7 @@
 			<Text>Merveille de l'ère antique.[ICON_AMENITIES] Activités +1 pour chaque camp, pâturage et plantation dans un rayon de 4 cases autour de cette merveille.[NEWLINE][NEWLINE]Doit être construite sur une case adjacente à un camp.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_PYRAMIDS_DESCRIPTION" Language="fr_FR">
-			<Text>Merveille de l'ère antique. Octoie un bâtisseur et une [ICON_CHARGES] charge à tous les bâtisseurs existants ou futurs.[NEWLINE][NEWLINE]Doit être construite sur une case de Désert plate (inondable ou non).</Text>
+			<Text>Merveille de l'ère antique. Octoie un Bâtisseur et une [ICON_CHARGES] charge à tous les Bâtisseurs existants ou futurs.[NEWLINE][NEWLINE]Doit être construite sur une case de Désert plate (inondable ou non).</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_GREAT_LIGHTHOUSE_DESCRIPTION" Language="fr_FR">
 			<Text>Merveille de l'ère classique. [ICON_MOVEMENT] PM +1 pour toutes les unités navales.[NEWLINE][NEWLINE]Doit être construite sur une case de côte adjacente à la terre et à un Port doté d'un phare.</Text>
@@ -2333,7 +2352,7 @@
 			<Text>Merveille de l'ère atomique.[NEWLINE][NEWLINE]Doit être construite sur une case de côte adjacente à la terre et à un Port.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_ESTADIO_DO_MARACANA_DESCRIPTION" Language="fr_FR">
-			<Text>Merveille de l'ère atomique. [ICON_Amenities] Activités +2 pour toutes vos villes[NEWLINE][NEWLINE]Doit être construite sur une case plate adjacente à un Complexe de loisirs doté d'un stade.</Text>
+			<Text>Merveille de l'ère atomique. [ICON_AMENITIES] Activités +2 pour toutes vos villes[NEWLINE][NEWLINE]Doit être construite sur une case plate adjacente à un Complexe de loisirs doté d'un stade.</Text>
 		</Replace>
 		<Replace Tag="LOC_BUILDING_AMUNDSEN_SCOTT_RESEARCH_STATION_DESCRIPTION" Language="fr_FR">
 			<Text>Merveille de l'ère atomique. [ICON_PRODUCTION] Production +10% et [ICON_SCIENCE] Science +20% dans toutes vos villes. Ces rendements sont doublés dans les villes possédant au moins 5 cases exploitables de Toundra.[NEWLINE][NEWLINE]Doit être construite sur une case de Neige ou de Toundra adjacente à un Campus doté d'un laboratoire de recherche.</Text>
@@ -2344,12 +2363,46 @@
 		<!-- === CITY-STATES - CITÉS-ÉTATS === -->
 		<!-- BONUS tag for City-states picker, DESCRIPTION tag for gameplay description -->
 		<!-- == MILITARISTIC == -->
+		<!-- = Akkad = -->
+		<Replace Tag="LOC_CIVILIZATION_AKKAD_BONUS" Language="fr_FR">
+			<Text>Les unités de combat rapproché et d'anti-cavalerie infligent des dégâts complets aux remparts de la ville.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_AKKAD_DESCRIPTION" Language="fr_FR">
+			<Text>Les unités de combat rapproché et d'anti-cavalerie infligent des dégâts complets aux remparts de la ville.</Text>
+		</Replace>
+		<!-- = Granada - Grenade = -->
+		<Replace Tag="LOC_CIVILIZATION_GRANADA_BONUS_XP2" Language="fr_FR">
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un alcázar.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1 et [ICON_CULTURE] Culture +2. [ICON_CULTURE] Culture +1 par Campement adjacent. Octroie une quantité de [ICON_SCIENCE] Science égale à 50% de l'Attrait de la case. [ICON_STRENGTH] Puissance de combat en défense +4 et gain instantané de 2 tours de retranchement. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte. Deux alcázars ne peuvent pas être adjacents.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_GRANADA_EXPANSION2_DESCRIPTION" Language="fr_FR">
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un alcázar.[NEWLINE][NEWLINE][ICON_PRODUCTION] Production +1 et [ICON_CULTURE] Culture +2. [ICON_CULTURE] Culture +1 par Campement adjacent. Octroie une quantité de [ICON_SCIENCE] Science égale à 50% de l'Attrait de la case. [ICON_STRENGTH] Puissance de combat en défense +4 et gain instantané de 2 tours de retranchement. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte. Deux alcázars ne peuvent pas être adjacents.</Text>
+		</Replace>
+		<Replace Tag="LOC_BBG_ALCAZAR_CULTURE_ENCAMPMENT" Language="fr_FR">
+			<Text>[ICON_CULTURE] Culture +{1_num} de la part des Campements adjacents.</Text>
+		</Replace>
 		<!-- = Kabul-Kaboul = -->
 		<Replace Tag="LOC_CIVILIZATION_KABUL_BONUS" Language="fr_FR">
 			<Text>Expérience de combat +100% pour les unités militaires lorsqu'elles engagent le combat.</Text>
 		</Replace>
 		<Replace Tag="LOC_LEADER_TRAIT_KABUL_DESCRIPTION" Language="fr_FR">
 			<Text>Expérience de combat +100% pour les unités militaires lorsqu'elles engagent le combat.</Text>
+		</Replace>
+		<!-- = Lahore = -->
+		<Replace Tag="LOC_CIVILIZATION_LAHORE_BONUS" Language="fr_FR">
+			<Text>Permet d'acheter une unité exclusive à Lahore, le Nihang. Possède un arbre de compétences spécifique. Peut être achetée avec de la [ICON_FAITH] Foi. [ICON_STRENGTH] Puissance de combat +15 si vous possédez une caserne. De même si vous possédez une armurerie ou une école militaire. Reçoit les bonus des [ICON_GREATGENERAL] Généraux illustres de toutes les ères.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_LAHORE_DESCRIPTION" Language="fr_FR">
+			<Text>Permet d'acheter une unité exclusive à Lahore, le Nihang. Possède un arbre de compétences spécifique. Peut être achetée avec de la [ICON_FAITH] Foi. [ICON_STRENGTH] Puissance de combat +15 si vous possédez une caserne. De même si vous possédez une armurerie ou une école militaire. Reçoit les bonus des [ICON_GREATGENERAL] Généraux illustres de toutes les ères.</Text>
+		</Replace>
+		<Replace Tag="LOC_UNIT_LAHORE_NIHANG_DESCRIPTION" Language="fr_FR">
+			<Text>Unité exclusive à la Cité-état de Lahore avec un arbre de compétences spécifique. Peut être achetée avec de la [ICON_FAITH] Foi. [ICON_STRENGTH] Puissance de combat +15 si vous possédez une caserne. De même si vous possédez une armurerie ou une école militaire. Reçoit les bonus des [ICON_GREATGENERAL] Généraux illustres de toutes les ères.</Text>
+		</Replace>
+		<!-- = Ngazagarmu = -->
+		<Replace Tag="LOC_CIVILIZATION_NGAZARGAMU_BONUS" Language="fr_FR">
+			<Text>Le prix en [ICON_GOLD] Or et en [ICON_FAITH] Foi des unités militaires ou de soutien terrestres baisse de 10% par bâtiment du Campement construit dans cette ville.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_NGAZARGAMU_DESCRIPTION" Language="fr_FR">
+			<Text>Le prix en [ICON_GOLD] Or et en [ICON_FAITH] Foi des unités militaires ou de soutien terrestres baisse de 10% par bâtiment du Campement construit dans cette ville.</Text>
 		</Replace>
 		<!-- = Preslav = -->
 		<Replace Tag="LOC_CIVILIZATION_PRESLAV_BONUS_XP1" Language="fr_FR">
@@ -2365,27 +2418,6 @@
 		<Replace Tag="LOC_LEADER_TRAIT_VALLETTA_DESCRIPTION" Language="fr_FR">
 			<Text>Les bâtiments du Centre-ville et du Campement peuvent être achetés avec de la [ICON_FAITH] Foi. Le coût d'achat de tous les remparts est réduit.</Text>
 		</Replace>
-		<!-- = Akkad = -->
-		<Replace Tag="LOC_CIVILIZATION_AKKAD_BONUS" Language="fr_FR">
-			<Text>Les unités de combat rapproché et d'anti-cavalerie infligent des dégâts complets aux remparts de la ville.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_AKKAD_DESCRIPTION" Language="fr_FR">
-			<Text>Les unités de combat rapproché et d'anti-cavalerie infligent des dégâts complets aux remparts de la ville.</Text>
-		</Replace>
-		<!-- = Ngazagarmu = -->
-		<Replace Tag="LOC_CIVILIZATION_NGAZARGAMU_BONUS" Language="fr_FR">
-			<Text>Le prix en [ICON_GOLD] Or et en [ICON_FAITH] Foi des unités militaires ou de soutien terrestres baisse de 10% par bâtiment du Campement construit dans cette ville.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_NGAZARGAMU_DESCRIPTION" Language="fr_FR">
-			<Text>Le prix en [ICON_GOLD] Or et en [ICON_FAITH] Foi des unités militaires ou de soutien terrestres baisse de 10% par bâtiment du Campement construit dans cette ville.</Text>
-		</Replace>
-		<!-- = Granada - Grenade = -->
-		<Replace Tag="LOC_CIVILIZATION_GRANADA_BONUS_XP2" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un alcázar.[NEWLINE][NEWLINE][ICON_CULTURE] Culture +2. Octroie une quantité de [ICON_SCIENCE] Science égale à 50% de l'attrait de la case. [ICON_STRENGTH] Puissance de combat en défense +4 et gain instantané de 2 tours de retranchement. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte. Deux alcázars ne peuvent pas être adjacents.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_GRANADA_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un alcázar.[NEWLINE][NEWLINE][ICON_CULTURE] Culture +2. Octroie une quantité de [ICON_SCIENCE] Science égale à 50% de l'attrait de la case. [ICON_STRENGTH] Puissance de combat en défense +4 et gain instantané de 2 tours de retranchement. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte. Deux alcázars ne peuvent pas être adjacents.</Text>
-		</Replace>
 		<!-- = Wolin = -->
 		<Replace Tag="LOC_CIVILIZATION_WOLIN_BONUS" Language="fr_FR">
 			<Text>Chaque victoire militaire rapporte une quantité de points de [ICON_GREATGENERAL] Général illustre (combat terrestre) ou de points [ICON_GREATADMIRAL] d'Amiral illustre (combat naval), égale à 25% de la [ICON_STRENGTH] Puissance de combat de l'unité vaincue (vitesse normale).</Text>
@@ -2393,21 +2425,21 @@
 		<Replace Tag="LOC_LEADER_TRAIT_WOLIN_DESCRIPTION" Language="fr_FR">
 			<Text>Chaque victoire militaire rapporte une quantité de points de [ICON_GREATGENERAL] Général illustre (combat terrestre) ou de points [ICON_GREATADMIRAL] d'Amiral illustre (combat naval), égale à 25% de la [ICON_STRENGTH] Puissance de combat de l'unité vaincue (vitesse normale).</Text>
 		</Replace>
-		<!-- = Lahore = -->
-		<Replace Tag="LOC_CIVILIZATION_LAHORE_BONUS" Language="fr_FR">
-			<Text>Permet d'acheter une unité exclusive à Lahore, le Nihang. Possède un arbre de compétences spécifique. Peut être achetée avec de la [ICON_FAITH] Foi. [ICON_STRENGTH] Puissance de combat +15 si vous possédez une caserne. De même si vous possédez une armurerie ou une école militaire. Reçoit les bonus des [ICON_GREATGENERAL] Généraux illustres de toutes les ères.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_LAHORE_DESCRIPTION" Language="fr_FR">
-			<Text>Permet d'acheter une unité exclusive à Lahore, le Nihang. Possède un arbre de compétences spécifique. Peut être achetée avec de la [ICON_FAITH] Foi. [ICON_STRENGTH] Puissance de combat +15 si vous possédez une caserne. De même si vous possédez une armurerie ou une école militaire. Reçoit les bonus des [ICON_GREATGENERAL] Généraux illustres de toutes les ères.</Text>
-		</Replace>
-[
+
 		<!-- == INDUSTRIAL == -->
+		<!-- = Auckland = -->
+		<Replace Tag="LOC_CIVILIZATION_AUCKLAND_BONUS" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +1 pour les cases de côte aménagées (passe à +2 une fois l'ère industrielle atteinte).</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_AUCKLAND_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +1 pour les cases de côte aménagées (passe à +2 une fois l'ère industrielle atteinte).</Text>
+		</Replace>
 		<!-- = Brussels - Bruxelles = -->
 		<Replace Tag="LOC_CIVILIZATION_BRUSSELS_BONUS" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +15 % pour la construction de merveilles dans vos villes.</Text>
+			<Text>[ICON_PRODUCTION] Production +15% pour la construction de merveilles dans vos villes.</Text>
 		</Replace>
 		<Replace Tag="LOC_LEADER_TRAIT_BRUSSELS_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +15 % pour la construction de merveilles dans vos villes.</Text>
+			<Text>[ICON_PRODUCTION] Production +15% pour la construction de merveilles dans vos villes.</Text>
 		</Replace>
 		<!-- = Buenos Aires = -->
 		<Replace Tag="LOC_CIVILIZATION_BUENOS_AIRES_BONUS" Language="fr_FR">
@@ -2416,84 +2448,70 @@
 		<Replace Tag="LOC_LEADER_TRAIT_BUENOS_AIRES_DESCRIPTION" Language="fr_FR">
 			<Text>Vos ressources bonus fonctionnent comme des ressources de luxe, vous octroyant une [ICON_AMENITIES] Activité par type.</Text>
 		</Replace>
-		<!-- = Hong Kong = -->
-		<Replace Tag="LOC_CIVILIZATION_HONG_KONG_BONUS" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +20 % pour tous vos projets de ville.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_HONG_KONG_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +20 % pour tous vos projets de ville.</Text>
-		</Replace>
-		<!-- = Mexico = -->
-		<Replace Tag="LOC_CIVILIZATION_MEXICO_CITY_BONUS" Language="fr_FR">
-			<Text>La zone d'effets régionaux des Zones industrielles, des Complexes de loisirs et des Parcs aquatiques augmente de 3 cases.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_MEXICO_CITY_DESCRIPTION" Language="fr_FR">
-			<Text>La zone d'effets régionaux des Zones industrielles, des Complexes de loisirs et des Parcs aquatiques augmente de 3 cases.</Text>
-		</Replace>
 		<!-- = Cardiff = -->
 		<Replace Tag="LOC_CIVILIZATION_CARDIFF_BONUS" Language="fr_FR">
-			<Text>[ICON_POWER] Électricité +2 pour chaque bâtiment du Port.</Text>
+			<Text>[ICON_PRODUCTION] Production +1, [ICON_GOLD] Or +1 et [ICON_POWER] Électricité +2 pour les bâtiments du Port.</Text>
 		</Replace>
 		<Replace Tag="LOC_LEADER_TRAIT_CARDIFF_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_POWER] Électricité +2 pour chaque bâtiment du Port.</Text>
+			<Text>[ICON_PRODUCTION] Production +1, [ICON_GOLD] Or +1 et [ICON_POWER] Électricité +2 pour les bâtiments du Port.</Text>
 		</Replace>
-		<!-- = Auckland = -->
-		<Replace Tag="LOC_CIVILIZATION_AUCKLAND_BONUS" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +1 pour les cases de côte (passe à +2 une fois l'ère industrielle atteinte).</Text>
+		<!-- = Hong Kong = -->
+		<Replace Tag="LOC_CIVILIZATION_HONG_KONG_BONUS" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +20% pour tous vos projets de ville.</Text>
 		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_AUCKLAND_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +1 pour les cases de côte (passe à +2 une fois l'ère industrielle atteinte).</Text>
+		<Replace Tag="LOC_LEADER_TRAIT_HONG_KONG_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +20% pour tous vos projets de ville.</Text>
 		</Replace>
 		<!-- = Johannesburg - Johannesbourg = -->
 		<Replace Tag="LOC_CIVILIZATION_JOHANNESBURG_BONUS" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +1 dans vos villes pour chaque type de ressource aménagée différent (passe à +2 à Industrialisation découverte).</Text>
+			<Text>[ICON_PRODUCTION] Production +1 dans vos villes pour chaque type de ressource aménagée différent (passe à +2 à l'Industrialisation).</Text>
 		</Replace>
 		<Replace Tag="LOC_LEADER_TRAIT_JOHANNESBURG_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +1 dans vos villes pour chaque type de ressource aménagée différent (passe à +2 à Industrialisation découverte).</Text>
+			<Text>[ICON_PRODUCTION] Production +1 dans vos villes pour chaque type de ressource aménagée différent (passe à +2 à l'Industrialisation).</Text>
+		</Replace>
+		<!-- = Mexico = -->
+		<Replace Tag="LOC_CIVILIZATION_MEXICO_CITY_BONUS" Language="fr_FR">
+			<Text>La zone d'effets régionaux des Zones industrielles, des Complexes de loisirs et des Parcs aquatiques augmente de 3 cases. [ICON_AMENITIES] Activités +1 pour les villes possédant un Aqueduc.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_MEXICO_CITY_DESCRIPTION" Language="fr_FR">
+			<Text>La zone d'effets régionaux des Zones industrielles, des Complexes de loisirs et des Parcs aquatiques augmente de 3 cases. [ICON_AMENITIES] Activités +1 pour les villes possédant un Aqueduc.</Text>
 		</Replace>
 		<!-- = Singapore - Singapour = -->
 		<Replace Tag="LOC_CIVILIZATION_SINGAPORE_BONUS" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +2 pour chaque [ICON_TRADEROUTE] route commerciale internationale partant de cette ville et rejoignant une civilisation étrangère.</Text>
+			<Text>[ICON_PRODUCTION] Production +2 pour les [ICON_TRADEROUTE] routes commerciales internationales.</Text>
 		</Replace>
 		<Replace Tag="LOC_LEADER_TRAIT_SINGAPORE_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +2 pour chaque [ICON_TRADEROUTE] route commerciale internationale partant de cette ville et rejoignant une civilisation étrangère.</Text>
+			<Text>[ICON_PRODUCTION] Production +2 pour les [ICON_TRADEROUTE] routes commerciales internationales.</Text>
 		</Replace>
 
 		<!-- == TRADE == -->
-		<!-- = Venise = -->
-		<Replace Tag="LOC_CIVILIZATION_ANTIOCH_BONUS" Language="fr_FR">
-			<Text>[ICON_GOLD] Or +1 pour chaque ressource luxe dans la ville d'arrivée pour vos [ICON_TRADEROUTE] routes commerciales internationales.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_ANTIOCH_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_GOLD] Or +1 pour chaque ressource luxe dans la ville d'arrivée pour vos [ICON_TRADEROUTE] routes commerciales internationales.</Text>
-		</Replace>
 		<!-- = Bandar Brunei = -->
 		<Replace Tag="LOC_CIVILIZATION_JAKARTA_BONUS" Language="fr_FR">
-			<Text>[ICON_GOLD] Or +1 pour toutes les [ICON_TRADEROUTE] routes commerciales traversant ou arrivant à vos [ICON_TRADINGPOST] comptoirs commerciaux étrangers.</Text>
+			<Text>[ICON_GOLD] Or +1 pour toutes les [ICON_TRADEROUTE] routes commerciales traversant ou arrivant à vos [ICON_TRADINGPOST] comptoirs commerciaux étrangers. [ICON_GOLD] Or +2 pour les [ICON_TRADEROUTE] routes commerciales.</Text>
 		</Replace>
 		<Replace Tag="LOC_LEADER_TRAIT_JAKARTA_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_GOLD] Or +1 pour toutes les [ICON_TRADEROUTE] routes commerciales traversant ou arrivant à vos [ICON_TRADINGPOST] comptoirs commerciaux étrangers.</Text>
-		</Replace>
-		<!-- = Mogadiscio = -->
-		<Replace Tag="LOC_CIVILIZATION_LISBON_BONUS" Language="fr_FR">
-			<Text>Tous vos [ICON_TRADEROUTE] négociants sont immunisés contre le pillage.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_LISBON_DESCRIPTION" Language="fr_FR">
-			<Text>Tous vos [ICON_TRADEROUTE] négociants sont immunisés contre le pillage.</Text>
-		</Replace>
-		<!-- = Zanzibar = -->
-		<Replace Tag="LOC_CIVILIZATION_ZANZIBAR_BONUS" Language="fr_FR">
-			<Text>Vous recevez de la [ICON_RESOURCE_CINNAMON] Cannelle et des [ICON_RESOURCE_CLOVES] Clous de girofle, deux ressources de luxe exclusives à Zanzibar qui offrent 4 [ICON_AMENITIES] Activités chacune.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_ZANZIBAR_DESCRIPTION" Language="fr_FR">
-			<Text>Vous recevez de la [ICON_RESOURCE_CINNAMON] Cannelle et des [ICON_RESOURCE_CLOVES] Clous de girofle, deux ressources de luxe exclusives à Zanzibar qui offrent 4 [ICON_AMENITIES] Activités chacune.</Text>
+			<Text>[ICON_GOLD] Or +1 pour toutes les [ICON_TRADEROUTE] routes commerciales traversant ou arrivant à vos [ICON_TRADINGPOST] comptoirs commerciaux étrangers. [ICON_GOLD] Or +2 pour les [ICON_TRADEROUTE] routes commerciales.</Text>
 		</Replace>
 		<!-- = Cahokia = -->
 		<Replace Tag="LOC_CIVILIZATION_CAHOKIA_BONUS" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un mont de Cahokia.[NEWLINE][NEWLINE][ICON_GOLD] Or +3 et [ICON_AMENITIES] Activités +1 ([ICON_AMENITIES] l'Activité est limitée à 1 par ville, puis 2 à la découverte de l'Histoire Naturelle). [ICON_FOOD] Nourriture +1 toutes les 2 cases de [ICON_DISTRICT] quartiers adjacentes à la Féodalité (pour chaque [ICON_DISTRICT] quartier adjacent à Pièces de Rechange). [ICON_HOUSING] Habitations +1 (passe à +2 à Patrimoine Culturel découvert). Deux monts de Cahokia ne peuvent pas être adjacents.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un mont de Cahokia.[NEWLINE][NEWLINE][ICON_GOLD] Or +3 et [ICON_AMENITIES] Activités +1 ([ICON_AMENITIES] l'Activité est limitée à 1 par ville, puis 2 à la découverte de l'Histoire Naturelle). [ICON_FOOD] Nourriture +1 toutes les 2 cases de [ICON_DISTRICT] quartiers adjacentes à la Féodalité (pour chaque [ICON_DISTRICT] quartier adjacent à Pièces de Rechange). [ICON_HOUSING] Habitations +1 (passe à +2 à Patrimoine Culturel découvert). Deux monts de Cahokia ne peuvent pas être adjacents.</Text>
 		</Replace>
 		<Replace Tag="LOC_LEADER_TRAIT_CAHOKIA_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un mont de Cahokia.[NEWLINE][NEWLINE][ICON_GOLD] Or +3 et [ICON_AMENITIES] Activités +1 ([ICON_AMENITIES] l'Activité est limitée à 1 par ville, puis 2 à la découverte de l'Histoire Naturelle). [ICON_FOOD] Nourriture +1 toutes les 2 cases de [ICON_DISTRICT] quartiers adjacentes à la Féodalité (pour chaque [ICON_DISTRICT] quartier adjacent à Pièces de Rechange). [ICON_HOUSING] Habitations +1 (passe à +2 à Patrimoine Culturel découvert). Deux monts de Cahokia ne peuvent pas être adjacents.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un mont de Cahokia.[NEWLINE][NEWLINE][ICON_GOLD] Or +3 et [ICON_AMENITIES] Activités +1 ([ICON_AMENITIES] l'Activité est limitée à 1 par ville, puis 2 à la découverte de l'Histoire Naturelle). [ICON_FOOD] Nourriture +1 toutes les 2 cases de [ICON_DISTRICT] quartiers adjacentes à la Féodalité (pour chaque [ICON_DISTRICT] quartier adjacent à Pièces de Rechange). [ICON_HOUSING] Habitations +1 (passe à +2 à Patrimoine Culturel découvert). Deux monts de Cahokia ne peuvent pas être adjacents.</Text>
+		</Replace>
+		<!-- = Hunza = -->
+		<Replace Tag="LOC_CIVILIZATION_HUNZA_BONUS" Language="fr_FR">
+			<Text>[ICON_GOLD] Or +1 toutes les 5 cases traversées par vos [ICON_TRADEROUTE] routes commerciales.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_HUNZA_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_GOLD] Or +1 toutes les 5 cases traversées par vos [ICON_TRADEROUTE] routes commerciales.</Text>
+		</Replace>
+		<!-- = Mogadiscio = -->
+		<Replace Tag="LOC_CIVILIZATION_LISBON_BONUS" Language="fr_FR">
+			<Text>Tous vos [ICON_TRADEROUTE] négociants sont immunisés contre le pillage. [ICON_GOLD] Or +2 pour les [ICON_TRADEROUTE] routes commerciales internationales.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_LISBON_DESCRIPTION" Language="fr_FR">
+			<Text>Tous vos [ICON_TRADEROUTE] négociants sont immunisés contre le pillage. [ICON_GOLD] Or +2 pour les [ICON_TRADEROUTE] routes commerciales internationales.</Text>
 		</Replace>
 		<!-- = Muscat - Mascate = -->
 		<Replace Tag="LOC_CIVILIZATION_MUSCAT_BONUS" Language="fr_FR">
@@ -2504,27 +2522,27 @@
 		</Replace>
 		<!-- = Samarkand - Samarcande = -->
 		<Replace Tag="LOC_CIVILIZATION_SAMARKAND_BONUS" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une dôme commercial.[NEWLINE][NEWLINE][ICON_GOLD] Or +2. [ICON_GOLD] Or +1 pour chaque ressource de luxe adjacente. [ICON_GOLD] Or +1 pour vos [ICON_TRADEROUTE] routes commerciales internationales pour chaque dôme commercial dans la ville d'origine. Deux dômes commerciaux ne peuvent pas être adjacents.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une dôme commercial.[NEWLINE][NEWLINE][ICON_GOLD] Or +2. [ICON_GOLD] Or +1 pour chaque ressource de luxe adjacente. [ICON_PRODUCTION] Production +1 et [ICON_GOLD] Or +1 pour vos [ICON_TRADEROUTE] routes commerciales internationales pour chaque dôme commercial dans la ville d'origine. Deux dômes commerciaux ne peuvent pas être adjacents.</Text>
 		</Replace>
 		<Replace Tag="LOC_LEADER_TRAIT_SAMARKAND_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une dôme commercial.[NEWLINE][NEWLINE][ICON_GOLD] Or +2. [ICON_GOLD] Or +1 pour chaque ressource de luxe adjacente. [ICON_GOLD] Or +1 pour vos [ICON_TRADEROUTE] routes commerciales internationales pour chaque dôme commercial dans la ville d'origine. Deux dômes commerciaux ne peuvent pas être adjacents.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une dôme commercial.[NEWLINE][NEWLINE][ICON_GOLD] Or +2. [ICON_GOLD] Or +1 pour chaque ressource de luxe adjacente. [ICON_PRODUCTION] Production +1 et [ICON_GOLD] Or +1 pour vos [ICON_TRADEROUTE] routes commerciales internationales pour chaque dôme commercial dans la ville d'origine. Deux dômes commerciaux ne peuvent pas être adjacents.</Text>
 		</Replace>
-		<!-- = Hunza = -->
-		<Replace Tag="LOC_CIVILIZATION_HUNZA_BONUS" Language="fr_FR">
-			<Text>[ICON_GOLD] Or +1 toutes les 5 cases traversées par vos [ICON_TRADEROUTE] routes commerciales.</Text>
+		<!-- = Venice - Venise = -->
+		<Replace Tag="LOC_CIVILIZATION_ANTIOCH_BONUS" Language="fr_FR">
+			<Text>[ICON_GOLD] Or +2 pour chaque ressource luxe dans la ville d'arrivée pour vos [ICON_TRADEROUTE] routes commerciales internationales.</Text>
 		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_HUNZA_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_GOLD] Or +1 toutes les 5 cases traversées par vos [ICON_TRADEROUTE] routes commerciales.</Text>
+		<Replace Tag="LOC_LEADER_TRAIT_ANTIOCH_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_GOLD] Or +2 pour chaque ressource luxe dans la ville d'arrivée pour vos [ICON_TRADEROUTE] routes commerciales internationales.</Text>
+		</Replace>
+		<!-- = Zanzibar = -->
+		<Replace Tag="LOC_CIVILIZATION_ZANZIBAR_BONUS" Language="fr_FR">
+			<Text>Vous recevez de la [ICON_RESOURCE_CINNAMON] Cannelle et des [ICON_RESOURCE_CLOVES] Clous de girofle, deux ressources de luxe exclusives à Zanzibar qui offrent 4 [ICON_AMENITIES] Activités chacune.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_ZANZIBAR_DESCRIPTION" Language="fr_FR">
+			<Text>Vous recevez de la [ICON_RESOURCE_CINNAMON] Cannelle et des [ICON_RESOURCE_CLOVES] Clous de girofle, deux ressources de luxe exclusives à Zanzibar qui offrent 4 [ICON_AMENITIES] Activités chacune.</Text>
 		</Replace>
 
 		<!-- == SCIENTIFIC == -->
-		<!-- = Geneva - Genève = -->
-		<Replace Tag="LOC_CIVILIZATION_GENEVA_BONUS" Language="fr_FR">
-			<Text>[ICON_SCIENCE] Science +15 % dans vos villes lorsque vous n'êtes en guerre avec aucune civilisation.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_GENEVA_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_SCIENCE] Science +15 % dans vos villes lorsque vous n'êtes en guerre avec aucune civilisation.</Text>
-		</Replace>
 		<!-- = Anshan = -->
 		<Replace Tag="LOC_CIVILIZATION_BABYLON_BONUS" Language="fr_FR">
 			<Text>[ICON_SCIENCE] Science +2 pour chaque chef-d'œuvre [ICON_GREATWORK_WRITING] littéraire. [ICON_SCIENCE] Science +1 pour chaque [ICON_GREATWORK_RELIC] relique et [ICON_GREATWORK_ARTIFACT] artefact.</Text>
@@ -2546,12 +2564,19 @@
 		<Replace Tag="LOC_LEADER_TRAIT_FEZ_DESCRIPTION" Language="fr_FR">
 			<Text>Lorsque l'une de vos unités religieuses convertit une ville pour la première fois, vous gagnez 10 points de [ICON_SCIENCE] Science par [ICON_CITIZEN] Citoyen de cette ville.</Text>
 		</Replace>
+		<!-- = Geneva - Genève = -->
+		<Replace Tag="LOC_CIVILIZATION_GENEVA_BONUS" Language="fr_FR">
+			<Text>[ICON_SCIENCE] Science +15% dans vos villes lorsque vous n'êtes en guerre avec d'autre civilisation.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_GENEVA_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_SCIENCE] Science +15% dans vos villes lorsque vous n'êtes en guerre avec d'autre civilisation.</Text>
+		</Replace>
 		<!-- = Hattusa = -->
 		<Replace Tag="LOC_CIVILIZATION_HATTUSA_BONUS_XP2" Language="fr_FR">
-			<Text>Vous octroie 2 ressources stratégiques de chaque type par tour. Ne concerne que les ressources découvertes, mais non aménagées.</Text>
+			<Text>Vous octroie 2 ressources stratégiques de chaque type par tour. Ne concerne que les ressources découvertes.</Text>
 		</Replace>
 		<Replace Tag="LOC_LEADER_TRAIT_HATTUSA_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>Vous octroie 2 ressources stratégiques de chaque type par tour. Ne concerne que les ressources découvertes, mais non aménagées.</Text>
+			<Text>Vous octroie 2 ressources stratégiques de chaque type par tour. Ne concerne que les ressources découvertes.</Text>
 		</Replace>
 		<!-- = Mitla = -->
 		<Replace Tag="LOC_CIVILIZATION_PALENQUE_BONUS" Language="fr_FR">
@@ -2562,10 +2587,10 @@
 		</Replace>
 		<!-- = Nalanda = -->
 		<Replace Tag="LOC_CIVILIZATION_NALANDA_BONUS" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un mahavihara.[NEWLINE][NEWLINE][ICON_SCIENCE] Science +2 et [ICON_HOUSING] Habitations +1. [ICON_SCIENCE] Science +1 pour chaque Campus adjacent (passe à +2 à Théorie Scientifique). [ICON_FAITH] Foi +1 pour chaque Lieu saint adjacent. À la construction de son premier mahavihara, le joueur reçoit une technologie aléatoire. Doit être construit sur un terrain plat. Deux mahaviharas ne peuvent pas être adjacents.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un mahavihara.[NEWLINE][NEWLINE][ICON_SCIENCE] Science +2 et [ICON_HOUSING] Habitations +1. [ICON_SCIENCE] Science +1 pour chaque Campus adjacent (passe à +2 à Théorie Scientifique). [ICON_FAITH] Foi +1 pour chaque Lieu saint adjacent. À la construction de son premier mahavihara, le joueur reçoit une technologie aléatoire. Doit être construit sur un terrain plat. Deux mahaviharas ne peuvent pas être adjacents.</Text>
 		</Replace>
 		<Replace Tag="LOC_LEADER_TRAIT_NALANDA_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un mahavihara.[NEWLINE][NEWLINE][ICON_SCIENCE] Science +2 et [ICON_HOUSING] Habitations +1. [ICON_SCIENCE] Science +1 pour chaque Campus adjacent (passe à +2 à Théorie Scientifique). [ICON_FAITH] Foi +1 pour chaque Lieu saint adjacent. À la construction de son premier mahavihara, le joueur reçoit une technologie aléatoire. Doit être construit sur un terrain plat. Deux mahaviharas ne peuvent pas être adjacents.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un mahavihara.[NEWLINE][NEWLINE][ICON_SCIENCE] Science +2 et [ICON_HOUSING] Habitations +1. [ICON_SCIENCE] Science +1 pour chaque Campus adjacent (passe à +2 à Théorie Scientifique). [ICON_FAITH] Foi +1 pour chaque Lieu saint adjacent. À la construction de son premier mahavihara, le joueur reçoit une technologie aléatoire. Doit être construit sur un terrain plat. Deux mahaviharas ne peuvent pas être adjacents.</Text>
 		</Replace>
 		<!-- = Taruga = -->		
 		<Replace Tag="LOC_CIVILIZATION_TARUGA_BONUS" Language="fr_FR">
@@ -2576,6 +2601,27 @@
 		</Replace>
 
 		<!-- == CULTURAL == -->
+		<!-- = Antananarivo = -->
+		<Replace Tag="LOC_CIVILIZATION_ANTANANARIVO_BONUS" Language="fr_FR">
+		  <Text>[ICON_CULTURE] Culture +2% par [ICON_GREATPERSON] Personnage illustre recruté, jusqu'à +30%.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_ANTANANARIVO_DESCRIPTION" Language="fr_FR">
+		  <Text>[ICON_CULTURE] Culture +2% par [ICON_GREATPERSON] Personnage illustre recruté, jusqu'à +30%.</Text>
+		</Replace>
+		<!-- = Ayutthaya = -->
+		<Replace Tag="LOC_CIVILIZATION_AYUTTHAYA_BONUS" Language="fr_FR">
+			<Text>Gain de [ICON_CULTURE] Culture égal à 20% du coût en [ICON_PRODUCTION] Production à chaque bâtiment terminé.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_AYUTTHAYA_DESCRIPTION" Language="fr_FR">
+			<Text>Gain de [ICON_CULTURE] Culture égal à 20% du coût en [ICON_PRODUCTION] Production à chaque bâtiment terminé.</Text>
+		</Replace>
+		<!-- = Caguana = -->
+		<Replace Tag="LOC_CIVILIZATION_CAGUANA_BONUS" Language="fr_FR">
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un batey.[NEWLINE][NEWLINE][ICON_CULTURE] Culture +1. [ICON_PRODUCTION] Production +1 pour chaque ressource stratégique adjacente, [ICON_GOLD] Or +1 pour chaque ressource de luxe adjacente et [ICON_CULTURE] Culture +1 pour chaque ressource bonus et Complexe de loisirs adjacents (passe à +2 à l'Exploration). Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte. Ne peut pas être construit à côté d'un autre batey.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_CAGUANA_DESCRIPTION" Language="fr_FR">
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un batey.[NEWLINE][NEWLINE][ICON_CULTURE] Culture +1. [ICON_PRODUCTION] Production +1 pour chaque ressource stratégique adjacente, [ICON_GOLD] Or +1 pour chaque ressource de luxe adjacente et [ICON_CULTURE] Culture +1 pour chaque ressource bonus et Complexe de loisirs adjacents (passe à +2 à l'Exploration). Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte. Ne peut pas être construit à côté d'un autre batey.</Text>
+		</Replace>
 		<!-- = Kumasi = -->
 		<Replace Tag="LOC_CIVILIZATION_KUMASI_BONUS" Language="fr_FR">
 			<Text>[ICON_GOLD] Or +1 et [ICON_CULTURE] Culture +2 pour chaque [ICON_DISTRICT] quartier spécialisé de la ville d'origine d'une [ICON_TRADEROUTE] route commerciale établie avec une Cité-état.</Text>
@@ -2585,10 +2631,10 @@
 		</Replace>
 		<!-- = Mohenjo Daro = -->
 		<Replace Tag="LOC_CIVILIZATION_MOHENJO_DARO_BONUS" Language="fr_FR">
-			<Text>[ICON_HOUSING] Habitations maximum pour vos villes par l'eau, comme si elles étaient toutes adjacentes à de l'eau douce.</Text>
+			<Text>[ICON_HOUSING] Habitations maximum pour toutes vos villes, comme si elles étaient toutes adjacentes à de l'eau douce.</Text>
 		</Replace>
 		<Replace Tag="LOC_LEADER_TRAIT_MOHENJO_DARO_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_HOUSING] Habitations maximum pour vos villes par l'eau, comme si elles étaient toutes adjacentes à de l'eau douce.</Text>
+			<Text>[ICON_HOUSING] Habitations maximum pour toutes vos villes, comme si elles étaient toutes adjacentes à de l'eau douce.</Text>
 		</Replace>
 		<!-- = Nan Madol = -->
 		<Replace Tag="LOC_CIVILIZATION_NAN_MADOL_BONUS" Language="fr_FR">
@@ -2597,6 +2643,13 @@
 		<Replace Tag="LOC_LEADER_TRAIT_NAN_MADOL_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_CULTURE] Culture +1 pour vos [ICON_DISTRICT] quartiers sur ou près des cases de côte ou de lac (passe à +2 à l'Exploration).</Text>
 		</Replace>
+		<!-- = Rapa Nui = -->
+		<Replace Tag="LOC_CIVILIZATION_RAPA_NUI_BONUS" Language="fr_FR">
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un moaï.[NEWLINE][NEWLINE][ICON_CULTURE] Culture +1. [ICON_CULTURE] Culture +1 tous les 2 moaïs adjacents (pour chaque moaï adjacent à Foires Médiévales). [ICON_CULTURE] Culture +2 si construit sur une case de sol volcanique ou sur une case adjacente. [ICON_CULTURE] Culture +1 si adjacent à une case de côte ou de lac. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_RAPA_NUI_DESCRIPTION" Language="fr_FR">
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un moaï.[NEWLINE][NEWLINE][ICON_CULTURE] Culture +1. [ICON_CULTURE] Culture +1 tous les 2 moaïs adjacents (pour chaque moaï adjacent à Foires Médiévales). [ICON_CULTURE] Culture +2 si construit sur une case de sol volcanique ou sur une case adjacente. [ICON_CULTURE] Culture +1 si adjacent à une case de côte ou de lac. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte.</Text>
+		</Replace>
 		<!-- = Vilnius = -->
 		<Replace Tag="LOC_CIVILIZATION_VILNIUS_BONUS_XP1" Language="fr_FR">
 			<Text>Toutes les Places du théâtre reçoivent +50%/+100%/+150% de bonus de proximité si vous possédez une alliance de niveau 1/2/3. Non cumulable avec plusieurs alliances.</Text>
@@ -2604,42 +2657,31 @@
 		<Replace Tag="LOC_LEADER_TRAIT_VILNIUS_DESCRIPTION" Language="fr_FR">
 			<Text>Toutes les Places du théâtre reçoivent +50%/+100%/+150% de bonus de proximité si vous possédez une alliance de niveau 1/2/3. Non cumulable avec plusieurs alliances.</Text>
 		</Replace>
-		<!-- = Rapa Nui = -->
-		<Replace Tag="LOC_CIVILIZATION_RAPA_NUI_BONUS" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un moaï.[NEWLINE][NEWLINE][ICON_CULTURE] Culture +1. [ICON_CULTURE] Culture +1 tous les 2 moaïs adjacents (pour chaque moaï adjacent à Foires Médiévales). [ICON_CULTURE] Culture +2 si construit sur une case de sol volcanique ou sur une case adjacente. [ICON_CULTURE] Culture +1 si adjacent à une case de côte ou de lac. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte. Peut être construit sur une case de plaine, de prairie, de colline de prairie ou de sol volcanique. Ne peut pas être adjacent à une case de bois ou de forêt tropicale.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_RAPA_NUI_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un moaï.[NEWLINE][NEWLINE][ICON_CULTURE] Culture +1. [ICON_CULTURE] Culture +1 tous les 2 moaïs adjacents (pour chaque moaï adjacent à Foires Médiévales). [ICON_CULTURE] Culture +2 si construit sur une case de sol volcanique ou sur une case adjacente. [ICON_CULTURE] Culture +1 si adjacent à une case de côte ou de lac. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte. Peut être construit sur une case de plaine, de prairie, de colline de prairie ou de sol volcanique. Ne peut pas être adjacent à une case de bois ou de forêt tropicale.</Text>
-		</Replace>
-		<!-- = Caguana = -->
-		<Replace Tag="LOC_CIVILIZATION_CAGUANA_BONUS" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un batey.[NEWLINE][NEWLINE][ICON_CULTURE] Culture +1. [ICON_CULTURE] Culture +1 pour chaque ressource bonus et complexe de loisirs adjacents (passe à +2 à l'Exploration). Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte. Ne peut pas être construit à côté d'un autre batey.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_CAGUANA_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un batey.[NEWLINE][NEWLINE][ICON_CULTURE] Culture +1. [ICON_CULTURE] Culture +1 pour chaque ressource bonus et complexe de loisirs adjacents (passe à +2 à l'Exploration). Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_CULTURE] Culture une fois l'Aviation découverte. Ne peut pas être construit à côté d'un autre batey.</Text>
-		</Replace>
-		<!-- = Ayutthaya = -->
-		<Replace Tag="LOC_CIVILIZATION_AYUTTHAYA_BONUS" Language="fr_FR">
-			<Text>Gain de [ICON_CULTURE] Culture égal à 20% du coût en [ICON_PRODUCTION] Production à chaque bâtiment terminé.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_AYUTTHAYA_DESCRIPTION" Language="fr_FR">
-			<Text>Gain de [ICON_CULTURE] Culture égal à 20% du coût en [ICON_PRODUCTION] Production à chaque bâtiment terminé.</Text>
-		</Replace>
-		<!-- = Antananarivo = -->
-		<Replace Tag="LOC_CIVILIZATION_ANTANANARIVO_BONUS" Language="fr_FR">
-		  <Text>[ICON_CULTURE] Culture +2% par [ICON_GREATPERSON] Personnage illustre recruté, jusqu'à +30%.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_ANTANANARIVO_DESCRIPTION" Language="fr_FR">
-		  <Text>[ICON_CULTURE] Culture +2% par [ICON_GREATPERSON] Personnage illustre recruté, jusqu'à +30%.</Text>
-		</Replace>
 
 		<!-- == RELIGIOUS == -->
+		<!-- = Armagh = -->
+		<Replace Tag="LOC_CIVILIZATION_ARMAGH_BONUS_XP2" Language="fr_FR">
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un monastère.[NEWLINE][NEWLINE][ICON_FAITH] Foi +3 et [ICON_HOUSING] Habitations +1. [ICON_FAITH] Foi +1 par [ICON_DISTRICT] quartier adjacent à l'Église Réformée. [ICON_HOUSING] Habitations +1 à Colonialisme. Régénération +15 pour les unités qui n'ont pas attaqué ce tour. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_FAITH] Foi après la découverte de l'Aviation. Ne peut pas être construit à côté d'un autre monastère.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_ARMAGH_EXPANSION2_DESCRIPTION" Language="fr_FR">
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un monastère.[NEWLINE][NEWLINE][ICON_FAITH] Foi +3 et [ICON_HOUSING] Habitations +1. [ICON_FAITH] Foi +1 par [ICON_DISTRICT] quartier adjacent à l'Église Réformée. [ICON_HOUSING] Habitations +1 à Colonialisme. Régénération +15 pour les unités qui n'ont pas attaqué ce tour. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_FAITH] Foi après la découverte de l'Aviation. Ne peut pas être construit à côté d'un autre monastère.</Text>
+		</Replace>
+		<Replace Tag="LOC_IMPROVEMENT_MONASTERY_EXPANSION2_DESCRIPTION" Language="fr_FR">
+			<Text>Débloque la compétence de Bâtisseur permettant de construire un monastère.[NEWLINE][NEWLINE][ICON_FAITH] Foi +3 et [ICON_HOUSING] Habitations +1. [ICON_FAITH] Foi +1 par [ICON_DISTRICT] quartier adjacent à l'Église Réformée. [ICON_HOUSING] Habitations +1 à Colonialisme. Régénération +15 pour les unités qui n'ont pas attaqué ce tour. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_FAITH] Foi après la découverte de l'Aviation. Ne peut pas être construit à côté d'un autre monastère.</Text>
+		</Replace>
+		<!-- = Chinguetti = -->
+		<Replace Tag="LOC_CIVILIZATION_CHINGUETTI_BONUS" Language="fr_FR">
+			<Text>[ICON_FAITH] Foi +1 pour les [ICON_TRADEROUTE] routes commerciales intérieures et internationales pour chaque fidèle de votre [ICON_RELIGION] religion (fondée ou adoptée) dans la ville d'origine.</Text>
+		</Replace>
+		<Replace Tag="LOC_LEADER_TRAIT_CHINGUETTI_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_FAITH] Foi +1 pour les [ICON_TRADEROUTE] routes commerciales intérieures et internationales pour chaque fidèle de votre [ICON_RELIGION] religion (fondée ou adoptée) dans la ville d'origine.</Text>
+		</Replace>
 		<!-- = Jerusalem - Jérusalem = -->
 		<Replace Tag="LOC_CIVILIZATION_JERUSALEM_BONUS_EXPANSION" Language="fr_FR">
-			<Text>Vos villes avec un Lieu saint exercent une pression religieuse comme si elles étaient des villes saintes : pression religieuse x4 pour toutes les villes dans un rayon de 12 cases.</Text>
+			<Text>Vos villes avec un Lieu saint exercent une pression religieuse comme si elles étaient des villes saintes : pression religieuse x4 pour toutes les villes dans un rayon de 12 cases. [ICON_GOLD] Or +1 pour les villes possédant un Lieu saint.</Text>
 		</Replace>
 		<Replace Tag="LOC_LEADER_TRAIT_JERUSALEM_DESCRIPTION_EXPANSION" Language="fr_FR">
-			<Text>Vos villes avec un Lieu saint exercent une pression religieuse comme si elles étaient des villes saintes : pression religieuse x4 pour toutes les villes dans un rayon de 12 cases.</Text>
+			<Text>Vos villes avec un Lieu saint exercent une pression religieuse comme si elles étaient des villes saintes : pression religieuse x4 pour toutes les villes dans un rayon de 12 cases. [ICON_GOLD] Or +1 pour les villes possédant un Lieu saint.</Text>
 		</Replace>
 		<!-- = Kandy = -->
 		<Replace Tag="LOC_CIVILIZATION_KANDY_BONUS" Language="fr_FR">
@@ -2650,17 +2692,17 @@
 		</Replace>
 		<!-- = La Venta = -->
 		<Replace Tag="LOC_CIVILIZATION_LA_VENTA_BONUS_XP2" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une tête colossale.[NEWLINE][NEWLINE][ICON_FAITH] Foi +2. [ICON_FAITH] Foi +1 toutes les 2 cases de forêt tropicale adjacentes (par case de forêt tropicale à Humanisme). [ICON_FAITH] Foi +1 toutes les 2 cases de bois adjacentes (par case de bois à Humanisme). Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_FAITH] Foi une fois l'Aviation découverte. Construction impossible sur la neige ou une colline enneigée.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une tête colossale.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1, [ICON_FAITH] Foi +2 et [ICON_HOUSING] Habitations +1. [ICON_FAITH] Foi +1 toutes les 2 cases de forêt tropicale adjacentes (par case de forêt tropicale à Humanisme). [ICON_FAITH] Foi +1 toutes les 2 cases de bois adjacentes (par case de bois à Humanisme). Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_FAITH] Foi une fois l'Aviation découverte. Construction impossible sur la neige ou une colline enneigée.</Text>
 		</Replace>
 		<Replace Tag="LOC_LEADER_TRAIT_LA_VENTA_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une tête colossale.[NEWLINE][NEWLINE][ICON_FAITH] Foi +2. [ICON_FAITH] Foi +1 toutes les 2 cases de forêt tropicale adjacentes (par case de forêt tropicale à Humanisme). [ICON_FAITH] Foi +1 toutes les 2 cases de bois adjacentes (par case de bois à Humanisme). Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_FAITH] Foi une fois l'Aviation découverte. Construction impossible sur la neige ou une colline enneigée.</Text>
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une tête colossale.[NEWLINE][NEWLINE][ICON_FOOD] Nourriture +1, [ICON_FAITH] Foi +2 et [ICON_HOUSING] Habitations +1. [ICON_FAITH] Foi +1 toutes les 2 cases de forêt tropicale adjacentes (par case de forêt tropicale à Humanisme). [ICON_FAITH] Foi +1 toutes les 2 cases de bois adjacentes (par case de bois à Humanisme). Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_FAITH] Foi une fois l'Aviation découverte. Construction impossible sur la neige ou une colline enneigée.</Text>
 		</Replace>
-		<!-- = Yerevan - Erevan = -->
-		<Replace Tag="LOC_CIVILIZATION_YEREVAN_BONUS" Language="fr_FR">
-			<Text>Vos Apôtres peuvent choisir n'importe quelle promotion, plutôt que de recevoir une promotion aléatoire.</Text>
+		<!-- = Nazca = -->
+		<Replace Tag="LOC_CIVILIZATION_NAZCA_BONUS" Language="fr_FR">
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une ligne de Nazca.[NEWLINE][NEWLINE][ICON_FAITH] Foi +1 pour les cases adjacentes. [ICON_FAITH] Foi +1 pour les cases adjacentes disposant d'une ressource. [ICON_FOOD] Nourriture +1 pour les cases de désert et de colline désertique adjacentes à Fonction Publique. [ICON_PRODUCTION] Production +1 pour les cases plates adjacentes à Production en Série. Attrait +1 pour les cases adjacentes. Ne peut être construit que sur une case de désert plat. Cette case ne peut pas être exploitée.</Text>
 		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_YEREVAN_DESCRIPTION" Language="fr_FR">
-			<Text>Vos Apôtres peuvent choisir n'importe quelle promotion, plutôt que de recevoir une promotion aléatoire.</Text>
+		<Replace Tag="LOC_LEADER_TRAIT_NAZCA_DESCRIPTION" Language="fr_FR">
+			<Text>Débloque la compétence de Bâtisseur permettant de construire une ligne de Nazca.[NEWLINE][NEWLINE][ICON_FAITH] Foi +1 pour les cases adjacentes. [ICON_FAITH] Foi +1 pour les cases adjacentes disposant d'une ressource. [ICON_FOOD] Nourriture +1 pour les cases de désert et de colline désertique adjacentes à Fonction Publique. [ICON_PRODUCTION] Production +1 pour les cases plates adjacentes à Production en Série. Attrait +1 pour les cases adjacentes. Ne peut être construit que sur une case de désert plat. Cette case ne peut pas être exploitée.</Text>
 		</Replace>
 		<!-- = Vatican = -->
 		<Replace Tag="LOC_CIVILIZATION_VATICAN_CITY_BONUS" Language="fr_FR">
@@ -2669,32 +2711,13 @@
 		<Replace Tag="LOC_LEADER_TRAIT_VATICAN_CITY_DESCRIPTION" Language="fr_FR">
 			<Text>Lorsque vous activez un [ICON_GREATPERSON] Personnage illustre, il génère 400 points de pression religieuse pour la [ICON_RELIGION] religion que vous avez fondée (ou dominante) dans les villes dans un rayon de 6 cases.</Text>
 		</Replace>
-		<!-- = Nazca = -->
-		<Replace Tag="LOC_CIVILIZATION_NAZCA_BONUS" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une ligne de Nazca.[NEWLINE][NEWLINE][ICON_FAITH] Foi +1 pour les cases adjacentes. [ICON_FAITH] Foi +1 pour les cases adjacentes disposant d'une ressource. [ICON_FOOD] Nourriture +1 pour les cases de désert et de colline désertique adjacentes à Fonction Publique. [ICON_PRODUCTION] Production +1 pour les cases plates adjacentes à Production en Série. Attrait +1 pour les cases adjacentes. Ne peut être construit que sur une case de désert plat. Cette case ne peut pas être exploitée.</Text>
+		<!-- = Yerevan - Erevan = -->
+		<Replace Tag="LOC_CIVILIZATION_YEREVAN_BONUS" Language="fr_FR">
+			<Text>Vos Apôtres peuvent choisir n'importe quelle promotion, plutôt que de recevoir une promotion aléatoire.</Text>
 		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_NAZCA_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire une ligne de Nazca.[NEWLINE][NEWLINE][ICON_FAITH] Foi +1 pour les cases adjacentes. [ICON_FAITH] Foi +1 pour les cases adjacentes disposant d'une ressource. [ICON_FOOD] Nourriture +1 pour les cases de désert et de colline désertique adjacentes à Fonction Publique. [ICON_PRODUCTION] Production +1 pour les cases plates adjacentes à Production en Série. Attrait +1 pour les cases adjacentes. Ne peut être construit que sur une case de désert plat. Cette case ne peut pas être exploitée.</Text>
+		<Replace Tag="LOC_LEADER_TRAIT_YEREVAN_DESCRIPTION" Language="fr_FR">
+			<Text>Vos Apôtres peuvent choisir n'importe quelle promotion, plutôt que de recevoir une promotion aléatoire.</Text>
 		</Replace>
-		<!-- = Armagh = -->
-		<Replace Tag="LOC_CIVILIZATION_ARMAGH_BONUS_XP2" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un monastère.[NEWLINE][NEWLINE][ICON_FAITH] Foi +3 et [ICON_HOUSING] Habitations +1. [ICON_FAITH] Foi +1 tous les 2 [ICON_DISTRICT] quartiers adjacents. [ICON_HOUSING] Habitations +1 à Colonialisme. Régénération +15 pour les unités qui n'ont pas attaqué ce tour. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_FAITH] Foi après la découverte de l'Aviation. Ne peut pas être construit à côté d'un autre monastère.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_ARMAGH_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un monastère.[NEWLINE][NEWLINE][ICON_FAITH] Foi +3 et [ICON_HOUSING] Habitations +1. [ICON_FAITH] Foi +1 tous les 2 [ICON_DISTRICT] quartiers adjacents. [ICON_HOUSING] Habitations +1 à Colonialisme. Régénération +15 pour les unités qui n'ont pas attaqué ce tour. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_FAITH] Foi après la découverte de l'Aviation. Ne peut pas être construit à côté d'un autre monastère.</Text>
-		</Replace>
-		<Replace Tag="LOC_IMPROVEMENT_MONASTERY_EXPANSION2_DESCRIPTION" Language="fr_FR">
-			<Text>Débloque la compétence de bâtisseur permettant de construire un monastère.[NEWLINE][NEWLINE][ICON_FAITH] Foi +3 et [ICON_HOUSING] Habitations +1. [ICON_FAITH] Foi +1 tous les 2 [ICON_DISTRICT] quartiers adjacents. [ICON_HOUSING] Habitations +1 à Colonialisme. Régénération +15 pour les unités qui n'ont pas attaqué ce tour. Génère du [ICON_TOURISM] Tourisme par le biais de la [ICON_FAITH] Foi après la découverte de l'Aviation. Ne peut pas être construit à côté d'un autre monastère.</Text>
-		</Replace>
-		<!-- = Chinguetti = -->
-		<Replace Tag="LOC_CIVILIZATION_CHINGUETTI_BONUS" Language="fr_FR">
-			<Text>[ICON_FAITH] Foi +1 pour les [ICON_TRADEROUTE] routes commerciales intérieures et internationales pour chaque fidèle de votre [ICON_RELIGION] religion (fondée ou adoptée) dans la ville d'origine.</Text>
-		</Replace>
-		<Replace Tag="LOC_LEADER_TRAIT_CHINGUETTI_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_FAITH] Foi +1 pour les [ICON_TRADEROUTE] routes commerciales intérieures et internationales pour chaque fidèle de votre [ICON_RELIGION] religion (fondée ou adoptée) dans la ville d'origine.</Text>
-		</Replace>
-
-
 
 		<!-- === AGES - ÂGES === -->
 		<!-- == Free Inquiry == -->
@@ -2750,7 +2773,7 @@
 			<Text>Monumentalité</Text>
 		</Replace>
 		<Replace Tag="LOC_MOMENT_CATEGORY_INFRASTRUCTURE_BONUS_GOLDEN_AGE" Language="fr_FR">
-			<Text>Âge d'or "Monumentalité" :[NEWLINE][ICON_MOVEMENT] PM +2 pour tous les bâtisseurs. Permet d'acheter des unités civiles avec de la [ICON_FAITH] Foi. Le coût en [ICON_FAITH] Foi et en [ICON_GOLD] Or des bâtisseurs et des colons est réduit de 10%.</Text>
+			<Text>Âge d'or "Monumentalité" :[NEWLINE][ICON_MOVEMENT] PM +2 pour tous les Bâtisseurs. Permet d'acheter des unités civiles avec de la [ICON_FAITH] Foi. Le coût en [ICON_FAITH] Foi et en [ICON_GOLD] Or des Bâtisseurs et des Colons est réduit de 10%.</Text>
 		</Replace>
 		<Replace Tag="LOC_MOMENT_CATEGORY_INFRASTRUCTURE_BONUS_NORMAL_AGE" Language="fr_FR">
 			<Text>Bonus d'engagement "Monumentalité" :[NEWLINE]Score d'ère +1 chaque fois que vous construisez un nouveau [ICON_DISTRICT] quartier spécialisé.</Text>
@@ -2759,7 +2782,7 @@
 			<Text>Bonus d'engagement "Monumentalité" :[NEWLINE]Score d'ère +1 chaque fois que vous construisez un nouveau [ICON_DISTRICT] quartier spécialisé.</Text>
 		</Replace>
 		<Replace Tag="LOC_PEDIA_CONCEPTS_PAGE_DEDICATIONS_CHAPTER_CONTENT_PARA_5" Language="fr_FR">
-			<Text>"Monumentalité" : score d'ère +1 chaque fois que vous construisez un nouveau [ICON_DISTRICT] quartier spécialisé. Choisi au début d'un âge d'or, [ICON_MOVEMENT] PM +2 pour tous les bâtisseurs. Permet d'acheter des unités civiles avec de la [ICON_FAITH] Foi. Le coût en [ICON_GOLD] Or et en [ICON_FAITH] Foi des bâtisseurs et des colons est réduit de 10%. De l'ère classique à la Renaissance.</Text>
+			<Text>"Monumentalité" : score d'ère +1 chaque fois que vous construisez un nouveau [ICON_DISTRICT] quartier spécialisé. Choisi au début d'un âge d'or, [ICON_MOVEMENT] PM +2 pour tous les Bâtisseurs. Permet d'acheter des unités civiles avec de la [ICON_FAITH] Foi. Le coût en [ICON_GOLD] Or et en [ICON_FAITH] Foi des Bâtisseurs et des cColons est réduit de 10%. De l'ère classique à la Renaissance.</Text>
         </Replace>
 		<!-- == Hic Sunt Dracones == -->
 		<Replace Tag="LOC_MOMENT_CATEGORY_EXPLORATION" Language="fr_FR">
@@ -2939,7 +2962,7 @@
 		<Replace Tag="LOC_TECH_PREDICTIVE_SYSTEMS_DESCRIPTION" Language="fr_FR">
 			<Text></Text>
 		</Replace>
-		<Replace Tag="LOC_TECH_SYNTHETIC_MATERIALS_DESCRIPTION" Language="fr_FR">
+		<Replace Tag="LOC_TECH_SYNTHETIC_QALS_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_PRODUCTION] Production +1 pour les scieries. [ICON_GOLD] Or +2 pour les camps.</Text>
 		</Replace>
 
@@ -3052,7 +3075,7 @@
 			<Text>Découvrez les Lumières.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_BALLISTICS" Language="fr_FR">
-			<Text>Faites construire 2 forts sur votre territoire par des ingénieurs militaires.</Text>
+			<Text>Possédez 2 forts aménagés par des ingénieurs militaires sur votre territoire.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_MILITARY_SCIENCE" Language="fr_FR">
 			<Text>Tuez une unité avec un chevalier.</Text>
@@ -3152,148 +3175,148 @@
 
 		<!-- == TRIGGERS - INSPIRATIONS == -->
 		<Replace Tag="LOC_BOOST_TRIGGER_CRAFTSMANSHIP" Language="fr_FR">
-		  <Text>Aménagez 3 cases.</Text>
+			<Text>Aménagez 3 cases.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_FOREIGN_TRADE" Language="fr_FR">
-		  <Text>Découvrez un deuxième continent.</Text>
+			<Text>Découvrez un deuxième continent.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_MILITARY_TRADITION" Language="fr_FR">
-		  <Text>Rasez un avant-poste barbare.</Text>
+			<Text>Rasez un avant-poste barbare.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_STATE_WORKFORCE" Language="fr_FR">
-		  <Text>Construisez un [ICON_DISTRICT] quartier spécialisé.</Text>
+			<Text>Construisez un [ICON_DISTRICT] quartier spécialisé.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_EARLY_EMPIRE" Language="fr_FR">
-		  <Text>Ayez 6 [ICON_CITIZEN] Citoyens dans votre Empire.</Text>
+			<Text>Ayez 6 [ICON_CITIZEN] Citoyens dans votre Empire.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_MYSTICISM" Language="fr_FR">
-		  <Text>Fondez un panthéon.</Text>
+			<Text>Fondez un panthéon.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_GAMES_RECREATION" Language="fr_FR">
-		  <Text>Découvrez la Construction.</Text>
+			<Text>Découvrez la Construction.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_POLITICAL_PHILOSOPHY" Language="fr_FR">
-		  <Text>Rencontrez 3 Cités-états.</Text>
+			<Text>Rencontrez 3 Cités-états.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_DRAMA_POETRY" Language="fr_FR">
-		  <Text>Construisez une merveille.</Text>
+			<Text>Construisez une merveille.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_MILITARY_TRAINING" Language="fr_FR">
-		  <Text>Possédez un Campement.</Text>
+			<Text>Possédez un Campement.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_DEFENSIVE_TACTICS" Language="fr_FR">
-		  <Text>Soyez la cible d'une déclaration de guerre.</Text>
+			<Text>Soyez la cible d'une déclaration de guerre.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_RECORDED_HISTORY" Language="fr_FR">
-		  <Text>Possédez 2 Campus.</Text>
+			<Text>Possédez 2 Campus.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_THEOLOGY" Language="fr_FR">
-		  <Text>Fondez une [ICON_RELIGION] religion.</Text>
+			<Text>Fondez une [ICON_RELIGION] religion.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_NAVAL_TRADITION" Language="fr_FR">
-		  <Text>Détruisez une unité avec une Quadrirème.</Text>
+			<Text>Détruisez une unité avec une Quadrirème.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_FEUDALISM" Language="fr_FR">
-		  <Text>Possédez 6 fermes.</Text>
+			<Text>Possédez 6 fermes.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_CIVIL_SERVICE" Language="fr_FR">
-		  <Text>Possédez une ville avec 10 [ICON_CITIZEN] Citoyens.</Text>
+			<Text>Possédez une ville avec 10 [ICON_CITIZEN] Citoyens.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_MERCENARIES" Language="fr_FR">
-		  <Text>Possédez 8 unités militaires terrestres.</Text>
+			<Text>Possédez 8 unités militaires terrestres.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_MEDIEVAL_FAIRES" Language="fr_FR">
-		  <Text>Entretenez 4 [ICON_TRADEROUTE] routes commerciales.</Text>
+			<Text>Entretenez 4 [ICON_TRADEROUTE] routes commerciales.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_GUILDS" Language="fr_FR">
-		  <Text>Possédez 2 marchés.</Text>
+			<Text>Possédez 2 marchés.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_DIVINE_RIGHT" Language="fr_FR">
-		  <Text>Possédez 2 temples.</Text>
+			<Text>Possédez 2 temples.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_EXPLORATION" Language="fr_FR">
-		  <Text>Possédez 2 Caravelles.</Text>
+			<Text>Possédez 2 Caravelles.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_HUMANISM" Language="fr_FR">
-		  <Text>Recrutez un [ICON_GREATARTIST] Artiste illustre.</Text>
+			<Text>Recrutez un [ICON_GREATARTIST] Artiste illustre.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_DIPLOMATIC_SERVICE" Language="fr_FR">
-		  <Text>Alliez-vous à une autre civilisation.</Text>
+			<Text>Alliez-vous à une autre civilisation.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_REFORMED_CHURCH" Language="fr_FR">
-		  <Text>Convertissez six villes à votre [ICON_RELIGION] religion.</Text>
+			<Text>Convertissez six villes à votre [ICON_RELIGION] religion.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_MERCANTILISM" Language="fr_FR">
-		  <Text>Recrutez un [ICON_GREATMERCHANT] Marchand illustre.</Text>
+			<Text>Recrutez un [ICON_GREATMERCHANT] Marchand illustre.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_THE_ENLIGHTENMENT" Language="fr_FR">
-		  <Text>Recrutez 3 [ICON_GREATPERSON] Personnages illustres.</Text>
+			<Text>Recrutez 3 [ICON_GREATPERSON] Personnages illustres.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_CIVIL_ENGINEERING" Language="fr_FR">
-		  <Text>Possédez 7 [ICON_DISTRICT] quartiers spécialisés différents.</Text>
+			<Text>Possédez 7 [ICON_DISTRICT] quartiers spécialisés différents.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_NATIONALISM" Language="fr_FR">
-		  <Text>Déclarez la guerre via un casus belli (une guerr.</Text>
+			<Text>Déclarez la guerre via un casus belli.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_OPERA_BALLET" Language="fr_FR">
-		  <Text>Possédez un musée d'art.</Text>
+			<Text>Possédez un musée d'art.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_COLONIALISM" Language="fr_FR">
-		  <Text>Découvrez l'Astronomie.</Text>
+			<Text>Découvrez l'Astronomie.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_NATURAL_HISTORY" Language="fr_FR">
-		  <Text>Possédez un musée archéologique.</Text>
+			<Text>Possédez un musée archéologique.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_URBANIZATION" Language="fr_FR">
-		  <Text>Possédez une ville avec 15 [ICON_CITIZEN] Citoyens.</Text>
+			<Text>Possédez une ville avec 15 [ICON_CITIZEN] Citoyens.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_SCORCHED_EARTH" Language="fr_FR">
-		  <Text>Possédez 2 Canons de campagne.</Text>
+			<Text>Possédez 2 Canons de campagne.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_CONSERVATION" Language="fr_FR">
-		  <Text>Possédez un Quartier résidentiel à l'Attrait époustouflant.</Text>
+			<Text>Possédez un Quartier résidentiel à l'Attrait époustouflant.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_MOBILIZATION" Language="fr_FR">
-		  <Text>Possédez 3 [ICON_CORPS] régiments.</Text>
+			<Text>Possédez 3 [ICON_CORPS] régiments.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_MASS_MEDIA" Language="fr_FR">
-		  <Text>Découvrez la Radio.</Text>
+			<Text>Découvrez la Radio.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_CAPITALISM_XP2" Language="fr_FR">
 			<Text>Possédez 2 bourses.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_NUCLEAR_PROGRAM" Language="fr_FR">
-		  <Text>Possédez un laboratoire de recherche.</Text>
+			<Text>Possédez un laboratoire de recherche.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_SUFFRAGE" Language="fr_FR">
-		  <Text>Possédez 4 réseaux d'égouts.</Text>
+			<Text>Possédez 4 réseaux d'égouts.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_TOTALITARIANISM" Language="fr_FR">
-		  <Text>Possédez 3 écoles militaires.</Text>
+			<Text>Possédez 3 écoles militaires.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_CLASS_STRUGGLE" Language="fr_FR">
-		  <Text>Possédez 3 usines.</Text>
+			<Text>Possédez 3 usines.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_COLD_WAR" Language="fr_FR">
-		  <Text>Découvrez la Fission Nucléaire.</Text>
+			<Text>Découvrez la Fission Nucléaire.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_PROFESSIONAL_SPORTS_XP2" Language="fr_FR">
 			<Text>Possédez 2 Complexes de loisirs.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_CULTURAL_HERITAGE" Language="fr_FR">
-		  <Text>Possédez un bâtiment thématique.</Text>
+			<Text>Possédez un bâtiment thématique.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_RAPID_DEPLOYMENT" Language="fr_FR">
-		  <Text>Possédez un Aérodrome ou une piste d'atterrissage sur un continent étranger.</Text>
+			<Text>Possédez un Aérodrome ou une piste d'atterrissage sur un continent étranger.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_SPACE_RACE" Language="fr_FR">
-		  <Text>Possédez un Spatioport.</Text>
+			<Text>Possédez un Spatioport.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_GLOBALIZATION_XP2" Language="fr_FR">
 			<Text>Possédez deux aéroports.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_SOCIAL_MEDIA" Language="fr_FR">
-		  <Text>Découvrez les Télécommunications.</Text>
+			<Text>Découvrez les Télécommunications.</Text>
 		</Replace>
 		<Replace Tag="LOC_BOOST_TRIGGER_ENVIRONMENTALISM" Language="fr_FR">
 			<Text>Possédez 2 centrales solaires.</Text>
@@ -3324,13 +3347,10 @@
       		<Text>[ICON_PRODUCTION] Production +1 par [ICON_CITIZEN] Citoyen dans une ville possédant un [ICON_GOVERNOR] gouverneur.</Text>
     	</Replace>
 		<Replace Tag="LOC_GOVT_INHERENT_BONUS_AUTOCRACY_ETHIOPIA" Language="fr_FR">
-			<Text>[ICON_FOOD][ICON_PRODUCTION][ICON_GOLD][ICON_SCIENCE][ICON_CULTURE][ICON_FAITH] Rendements +1 dans le palais, la Place de la gouvernance, le Quartier diplomatique et tous leurs bâtiments.</Text>
+			<Text>[ICON_FOOD][ICON_PRODUCTION][ICON_GOLD][ICON_SCIENCE][ICON_CULTURE][ICON_FAITH] Rendements +1 dans le palais, la Place de la gouvernance, le Quartier diplomatique et tous leurs bâtiments. [ICON_FOOD] Nourriture +1 et [ICON_PRODUCTION] Production +1 pour les villes possédant un monument et un [ICON_DISTRICT] quartier spécialisé.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVT_ACCUMULATED_BONUS_BRIEF_THEOCRACY_XP1" Language="fr_FR">
-			<Text>Achats avec de la [ICON_FAITH] foi -10 %.</Text>
-		</Replace>
-		<Replace Tag="LOC_POLICY_TWILIGHT_VALOR_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_STRENGTH] Puissance de combat en attaque +5 pour toutes les unités de mêlée (combat rapproché (terrestre et navale), anti-cavalerie, cavalerie légère, cavalerie lourde).[NEWLINE]MAIS : pas de soins hors de votre territoire.</Text>
+			<Text>Achats avec de la [ICON_FAITH] foi -15%.</Text>
 		</Replace>
 		<Replace Tag="LOC_GOVT_INHERENT_BONUS_DIGITAL_DEMOCRACY" Language="fr_FR">
 			<Text>[ICON_AMENITIES] Activités +2 dans toutes les villes et [ICON_CULTURE] Culture +2 pour chaque [ICON_DISTRICT] quartier spécialisé.</Text>
@@ -3350,21 +3370,43 @@
 		<Replace Tag="LOC_GOVT_ACCUMULATED_BONUS_BRIEF_CORPORATE_LIBERTARIANISM" Language="fr_FR">
 			<Text>[ICON_RESOURCE_OIL] Pétrole +5, [ICON_RESOURCE_ALUMINUM] Aluminium +5 et [ICON_RESOURCE_URANIUM] Uranium +5 par tour</Text>
 		</Replace>
+		<Replace Tag="LOC_GOVT_INHERENT_BONUS_MONARCHY_XP1" Language="fr_FR">
+			<Text>[ICON_HOUSING] Habitations +1 pour chaque niveau de remparts. [ICON_CULTURE] Culture +2 pour les remparts de la Renaissance.</Text>
+		</Replace>
 
 
 
 		<!-- === POLICIES - DOCTRINES === -->
-		<Replace Tag="LOC_POLICY_COLLECTIVIZATION_DESCRIPTION_XP2" Language="fr_FR">
-			<Text>[ICON_FOOD] Nourriture +4 et [ICON_PRODUCTION] Production +4 pour vos [ICON_TRADEROUTE] routes commerciales intérieures. [ICON_GOLD] Or +4 pour toutes les routes commerciales.</Text>
+		<!-- == MILITARY - MILITAIRE == -->
+		<Replace Tag="LOC_POLICY_DISCIPLINE_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_STRENGTH] Puissance de combat +10 contre les [ICON_BARBARIAN] barbares.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_SURVEY_DESCRIPTION" Language="fr_FR">
+			<Text>Expérience +100% pour les unités de reconnaissance.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_AGOGE_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +50% pour les unités de combat rapproché, combat à distance, anti-cavalerie et reconnaissance, des ères antique et classique.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_MARITIME_INDUSTRIES_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +100 % pour les unités navales des ères antique et classique.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_MANEUVER_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +50% pour les unités de cavalerie légère et cavalerie lourde des ères antique et classique.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_CONSCRIPTION_DESCRIPTION" Language="fr_FR">
+			<Text>Coût d'entretien -1 pour les unités militaires.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_LIMITANEI_DESCRIPTION" Language="fr_FR">
+			<Text>Loyauté +2 par tour pour les cités possédant une unité en garnison.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_RAID_EXPANSION1_ALT_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PILLAGED] Rendements +50% pour les pillages et assauts côtiers.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_VETERANCY_DESCRIPTION_XP2" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +30% pour les Campements, les Ports et leurs bâtiments.</Text>
 		</Replace>
 		<Replace Tag="LOC_POLICY_EQUESTRIAN_ORDERS_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_RESOURCE_HORSES] Chevaux +2 et [ICON_RESOURCE_IRON] Fer +2 par tour, ainsi que +1 par tour pour toutes les ressources de [ICON_RESOURCE_HORSES] Chevaux et de [ICON_RESOURCE_IRON] Fer aménagées.</Text>
-		</Replace>
-		<Replace Tag="LOC_POLICY_DRILL_MANUALS_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_RESOURCE_NITER] Salpêtre +2 et [ICON_RESOURCE_COAL] Charbon +2 par tour, ainsi que +1 par tour pour toutes les ressources de [ICON_RESOURCE_NITER] Salpêtre et de [ICON_RESOURCE_COAL] Charbon aménagées.</Text>
-		</Replace>
-		<Replace Tag="LOC_POLICY_RESOURCE_MANAGEMENT_DESCRIPTION_XP2" Language="fr_FR">
-			<Text>[ICON_RESOURCE_OIL] Pétrole +2 et [ICON_RESOURCE_ALUMINUM] Aluminium +2 par tour, ainsi que +1 par tour pour toutes les ressources de [ICON_RESOURCE_OIL] Pétrole et [ICON_RESOURCE_ALUMINUM] d'Aluminium aménagées.</Text>
 		</Replace>
 		<Replace Tag="LOC_POLICY_SIEGE_NAME" Language="fr_FR">
 			<Text>Artisanat obsidional</Text>
@@ -3375,6 +3417,24 @@
 		<Replace Tag="LOC_PEDIA_GOVERNMENTS_PAGE_POLICY_SIEGE_CHAPTER_HISTORY_PARA_1" Language="fr_FR">
 			<Text>Pendant la guerre du Péloponnèse, une centaine de sièges furent tentés et 58 se terminèrent par la reddition de la zone assiégée.[NEWLINE]L'Armée d'Alexandre le Grand assiégea avec succès de nombreuses villes puissantes au cours de ses conquêtes. Deux de ses réalisations les plus impressionnantes en matière de siège ont eu lieu lors du siège de Tyr et du siège du rocher de Sogdian. Ses ingénieurs construisirent une chaussée d'une largeur initiale de 60 m et atteignirent la portée de son artillerie à torsion, tandis que ses soldats poussaient des tours de siège abritant des lanceurs de pierres et des catapultes légères pour bombarder les murailles de la ville.[EWLINE]La plupart des conquérants avant lui avaient trouvé Tyr, une ville insulaire phénicienne située à environ 1 km du continent, imprenable. Les Macédoniens construisirent une taupe, une broche de terre surélevée à travers l'eau, en empilant des pierres sur un pont terrestre naturel qui se prolongeait sous l'eau jusqu'à l'île, et bien que les Tyriens se rallièrent en envoyant un bateau de pompiers pour détruire les tours, et capturèrent la taupe dans une frénésie de frénésie, la ville tomba finalement aux mains des Macédoniens après un siège de sept mois. Contrairement à Tyr, Sogdian Rock fut capturé par une attaque furtive. Alexandre utilisa des tactiques de commando pour escalader les falaises et capturer les hautes terres, et les défenseurs démoralisés se rendirent.</Text>
 		</Replace>
+		<Replace Tag="LOC_POLICY_BASTIONS_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_STRENGTH][ICON_BOMBARD] Puissance de combat +6 pour les villes avec des murs.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_LIMES_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +50% pour les bâtiments de défense.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FEUDAL_CONTRACT_DESCRIPTION" Language="fr_FR">
+      		<Text>[ICON_PRODUCTION] Production +50% pour les unités de combat rapproché, combat à distance, anti-cavalerie et reconnaissance, des ères de la Renaissance et antérieures.</Text>
+    	</Replace>
+		<Replace Tag="LOC_POLICY_RETAINERS_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_AMENITIES] Activités +1 pour les villes dans lesquelles une unité est en garnison.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_PROFESSIONAL_ARMY_DESCRIPTION_XP2" Language="fr_FR">
+			<Text>50% de réduction en [ICON_GOLD] Or pour l'amélioration d'unité.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_RETINUES_DESCRIPTION" Language="fr_FR">
+			<Text>50% de réduction en ressources pour la Production et l'amélioration d'unité.</Text>
+		</Replace>
 		<Replace Tag="LOC_POLICY_HARD_SHELL_EXPLOSIVES_NAME" Language="fr_FR">
 			<Text>Obus explosifs</Text>
 		</Replace>
@@ -3383,6 +3443,42 @@
 		</Replace>
 		<Replace Tag="LOC_PEDIA_GOVERNMENTS_PAGE_POLICY_HARD_SHELL_EXPLOSIVES_CHAPTER_HISTORY_PARA_1" Language="fr_FR">
 			<Text>Selon l'histoire, vers 1189, Iron Li développa une nouvelle méthode de chasse au renard qui utilisait un explosif en céramique pour effrayer les renards dans ses filets. L'explosif était constitué d'une bouteille en céramique munie d'une bouche, remplie de poudre à canon et attachée par un fusible. Quand ils s'approchaient suffisamment, Iron Li allumait le fusible, provoquant l'explosion de la bouteille en céramique et effrayant les renards effrayés dans ses filets.[NEWLINE]Bien que l'histoire soit fantaisiste, on ne sait pas exactement pourquoi cela aurait provoqué le développement de la bombe en fer, puisque l'explosif a été fabriqué à partir de céramique et d'autres matériaux comme le bambou ou même le cuir auraient fait le même travail, en supposant qu'ils aient fait suffisamment de bruit. Néanmoins, la bombe de fer apparut pour la première fois en 1221 lors du siège de Qizhou (dans la province moderne du Hubei), et cette fois ce sont les Jin qui possédaient l'avantage technologique. Le commandant Song Zhao Yurong a survécu et a pu relayer son récit pour la postérité.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_CRAFTSMEN_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_DISTRICT_INDUSTRIAL_ZONE]Bonus de proximité +100% pour les Zones industrielles.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_CHIVALRY_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +50 % pour les unités de cavalerie légère et cavalerie lourde des ère industrielle et antérieures.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_PRESS_GANGS_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +100 % pour les unités navales des ères industrielle et antérieures.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_WARS_OF_RELIGION_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_STRENGTH] Puissance de combat +4 pour les unités militaires affrontant une civilisation d'une autre religion.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_LOGISTICS_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_MOVEMENT] PM +1 si l'unité commence son tour en territoire allié.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_DRILL_MANUALS_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_RESOURCE_NITER] Salpêtre +2 et [ICON_RESOURCE_COAL] Charbon +2 par tour, ainsi que +1 par tour pour toutes les ressources de [ICON_RESOURCE_NITER] Salpêtre et de [ICON_RESOURCE_COAL] Charbon aménagées.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_NATIVE_CONQUEST_DESCRIPTION" Language="fr_FR">
+			<Text>Les victoires militaires génèrent une quantité [ICON_GOLD] d'Or égale à 25% de la [ICON_STRENGTH] Puissance de combat de l'unité vaincue (vitesse en ligne).</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_GRANDE_ARMEE_DESCRIPTION" Language="fr_FR">
+      		<Text>[ICON_PRODUCTION] Production +50% pour les unités de combat rapproché, combat à distance, anti-cavalerie et reconnaissance, des ères morderne et antérieures.</Text>
+    	</Replace>
+		<Replace Tag="LOC_POLICY_NATIONAL_IDENTITY_DESCRIPTION" Language="fr_FR">
+			<Text>Malus de [ICON_STRENGTH] Puissance de combat pour les unités blessées réduit de 50%.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_MILITARY_RESEARCH_EXPANSION1_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_SCIENCE] Science +2 pour les écoles militaires, les complexes portuaires et les remparts de la Renaissance.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FORCE_MODERNIZATION_DESCRIPTION" Language="fr_FR">
+			<Text>50% de réduction en ressources et en [ICON_GOLD] Or pour la Production et l'amélioration d'unité.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_TOTAL_WAR_EXPANSION1_ALT_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PILLAGED] Rendements +50 % pour les pillages, les assauts côtiers et le pillage de [ICON_TRADEROUTE] routes commerciales.</Text>
 		</Replace>
 		<Replace Tag="LOC_POLICY_TRENCH_WARFARE_NAME" Language="fr_FR">
 			<Text>Guerre de tranchées</Text>
@@ -3393,111 +3489,323 @@
 		<Replace Tag="LOC_PEDIA_GOVERNMENTS_PAGE_POLICY_TRENCH_WARFARE_CHAPTER_HISTORY_PARA_1" Language="fr_FR">
 			<Text>La guerre de tranchées est un type de guerre terrestre utilisant des lignes de combat occupées comprenant principalement des tranchées militaires, dans lesquelles les troupes sont bien protégées des tirs d'armes légères de l'ennemi et sont largement à l'abri de l'artillerie. La guerre dans les tranchées est devenue un archétype associé à la Première Guerre mondiale (1914-1918), lorsque la Course à la mer étend rapidement l'utilisation des tranchées sur le front occidental à partir de septembre 1914. [NOUVELLE]La guerre dans les tranchées prolifère lorsqu'une révolution de la puissance de feu ne s'accompagne pas d'avancées similaires en matière de mobilité. Sur le front de l'Ouest, en 1914–1918, les deux camps construisent des tranchées, des souterrains et des réseaux d'étangs-réservoirs qui s'opposent le long d'un front, protégés des attaques par des barbelés. La zone située entre les lignes de tranchées opposées (connue sous le nom de « no man's land ») était entièrement exposée aux tirs d'artillerie des deux côtés. Les attaques, même couronnées de succès, ont souvent fait de lourdes victimes.</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_RATIONALISM_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_SCIENCE] Science des bâtiments des Campus : +50% si la ville compte au moins 13 [ICON_CITIZEN] Citoyens, +50% si le quartier a un bonus de proximité d'au moins +3.</Text>
+		<Replace Tag="LOC_POLICY_RESOURCE_MANAGEMENT_DESCRIPTION_XP2" Language="fr_FR">
+			<Text>[ICON_RESOURCE_OIL] Pétrole +2 et [ICON_RESOURCE_ALUMINUM] Aluminium +2 par tour, ainsi que +1 par tour pour toutes les ressources de [ICON_RESOURCE_OIL] Pétrole et [ICON_RESOURCE_ALUMINUM] d'Aluminium aménagées.</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_SIMULTANEUM_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_FAITH] Foi des bâtiments des Lieux saints : +50% si la ville compte au moins 13 [ICON_CITIZEN] Citoyens, +50% si le quartier a un bonus de proximité d'au moins +3.</Text>
+		<Replace Tag="LOC_POLICY_PROPAGANDA_DESCRIPTION" Language="fr_FR">
+			<Text>L'usure de la guerre progresse 25% moins vite.</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_GRAND_OPERA_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_CULTURE] Culture des bâtiments des Places du théâtre : +50% si la ville compte au moins 13 [ICON_CITIZEN] Citoyens, +50% si le quartier a un bonus de proximité d'au moins +3.</Text>
+		<Replace Tag="LOC_POLICY_LEVEE_EN_MASSE_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_GOLD] Coût d'entretien -2 pour les unités militaires</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_FREE_MARKET_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_GOLD] Or des bâtiments des Plateformes commerciales : +50% si la ville compte au moins 13 [ICON_CITIZEN] Citoyens, +50% si le quartier a un bonus de proximité d'au moins +4.</Text>
+		<Replace Tag="LOC_POLICY_MILITARY_FIRST_DESCRIPTION" Language="fr_FR">
+      		<Text>[ICON_PRODUCTION] Production +50% pour les unités de combat rapproché, combat à distance, anti-cavalerie et reconnaissance, de toutes les ères.</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_DISCIPLINE_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_STRENGTH] Puissance de combat +10 contre les [ICON_BARBARIAN] barbares.</Text>
+		<Replace Tag="LOC_POLICY_LIGHTNING_WARFARE_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +50 % pour les unités de cavalerie légère et cavalerie lourde.</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_LIMES_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +50% pour les bâtiments de défense.</Text>
+		<Replace Tag="LOC_POLICY_THIRD_ALTERNATIVE_DESCRIPTION_XP2" Language="fr_FR">
+			<Text>[ICON_GOLD] Or +4 et [ICON_CULTURE] Culture +2 pour chaque laboratoire de recherche, école militaire et centrale .</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_BASTIONS_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_STRENGTH][ICON_BOMBARD] Puissance de combat +6 pour les villes avec des murs.</Text>
+		<Replace Tag="LOC_POLICY_INTERNATIONAL_WATERS_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +100% pour les unités navales de toutes les ères, sauf le porte-avions.</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_PRAETORIUM_DESCRIPTION" Language="fr_FR">
-			<Text>Loyauté +4 par tour dans les villes où est installé un [ICON_GOVERNOR] gouverneur.</Text>
+		<Replace Tag="LOC_POLICY_SECOND_STRIKE_CAPABILITY_DESCRIPTION" Language="fr_FR">
+			<Text>Coût d'entretien -50% pour les armes nucléaires.</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_COMMUNICATIONS_OFFICE_DESCRIPTION" Language="fr_FR">
-			<Text>Loyauté +2 par tour par [ICON_GOVERNOR] gouverneur et par promotion qu'il possède dans sa ville.</Text>
+		<Replace Tag="LOC_POLICY_AFTER_ACTION_REPORTS_DESCRIPTION" Language="fr_FR">
+			<Text>Expérience de combat +25% pour toutes les unités.</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_RETINUES_DESCRIPTION" Language="fr_FR">
-			<Text>50% de réduction sur les ressources pour toutes la production et l'amélioration d'unité.</Text>
+		<Replace Tag="LOC_POLICY_INTEGRATED_SPACE_CELL_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +15% pour les projets de la course à l'espace dans les villes possédant une école militaire ou un complexe portuaire.</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_FORCE_MODERNIZATION_DESCRIPTION" Language="fr_FR">
-			<Text>50% de réduction sur [ICON_GOLD] l'Or et les ressources pour la Production et l'amélioration d'unité.</Text>
+		<Replace Tag="LOC_POLICY_STRATEGIC_AIR_FORCE_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +50% pour les unités aériennes et les porte-avions.</Text>
 		</Replace>
-		<Replace Tag="LOC_GOVT_INHERENT_BONUS_MONARCHY_XP1" Language="fr_FR">
-			<Text>[ICON_HOUSING] Habitations +1 pour chaque niveau de remparts. [ICON_CULTURE] Culture +2 pour les remparts de la Renaissance.</Text>
+
+		<!-- == ECONOMIC - ÉCONOMIQUE == -->
+		<Replace Tag="LOC_POLICY_GOD_KING_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_GOLD] Or +1 et [ICON_FAITH] Foi +1 dans la [ICON_CAPITAL] Capitale.</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_CHARISMATIC_LEADER_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_INFLUENCEPERTURN] Points d'influence +2 par tour.</Text>
+		<Replace Tag="LOC_POLICY_URBAN_PLANNING_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +1 dans toutes les villes.</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_GUNBOAT_DIPLOMACY_DESCRIPTION" Language="fr_FR">
-			<Text>Libre passage avec toutes les Cités-états et [ICON_INFLUENCEPERTURN] Points d'influence +4 par tour.</Text>
+		<Replace Tag="LOC_POLICY_ILKUM_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +30% pour les Bâtisseurs.</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_NUCLEAR_ESPIONAGE_DESCRIPTION" Language="fr_FR">
-			<Text>Les espions qui volent un [ICON_TECHBOOSTED] Eurêka ! sans se faire repérer gagne un autre [ICON_TECHBOOSTED] Eurêka !</Text>
+		<Replace Tag="LOC_POLICY_CARAVANSARIES_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_GOLD] Or +2 pour les [ICON_TRADEROUTE] routes commerciales.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_CORVEE_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +15% pour les merveilles des ères antique et classique.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_LAND_SURVEYORS_DESCRIPTION" Language="fr_FR">
+			<Text>Coût d'achat de cases réduit de 20%.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_COLONIZATION_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +50% pour les Colons.</Text>
 		</Replace>
 		<Replace Tag="LOC_POLICY_INSULAE_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_HOUSING] Habitations +1 dans toutes les villes qui possèdent au moins 1 [ICON_DISTRICT] quartier spécialisé.</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_AGOGE_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +50% pour les unités de combat rapproché, combat à distance, anti-cavalerie et reconnaissance, des ères antique et classique.</Text>
-		</Replace>
-		<Replace Tag="LOC_POLICY_FEUDAL_CONTRACT_DESCRIPTION" Language="fr_FR">
-      		<Text>[ICON_PRODUCTION] Production +50% pour les unités de combat rapproché, combat à distance, anti-cavalerie et reconnaissance, des ères de la Renaissance et antérieures.</Text>
-    	</Replace>
-		<Replace Tag="LOC_POLICY_GRANDE_ARMEE_DESCRIPTION" Language="fr_FR">
-      		<Text>[ICON_PRODUCTION] Production +50% pour les unités de combat rapproché, combat à distance, anti-cavalerie et reconnaissance, des ères industrielle et antérieures.</Text>
-    	</Replace>
-		<Replace Tag="LOC_POLICY_MILITARY_FIRST_DESCRIPTION" Language="fr_FR">
-      		<Text>[ICON_PRODUCTION] Production +50% pour les unités de combat rapproché, combat à distance, anti-cavalerie et reconnaissance, de toutes les ères.</Text>
-		</Replace>
-		<Replace Tag="LOC_POLICY_PUBLIC_TRANSPORT_DESCRIPTION_XP2" Language="fr_FR">
-      		<Text>[ICON_FOOD] Nourriture +3 et [ICON_PRODUCTION] Production +1 pour les Quartiers résidentiels d'un Attrait charmant (+4 et +2 si le quartier est époustouflant). [ICON_GOLD] Or +1 pour tous les Quartiers résidentiels.</Text>
-    	</Replace>
-		<Replace Tag="LOC_POLICY_LETTERS_OF_MARQUE_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_PRODUCTION] Production +100% et [ICON_MOVEMENT] PM +2 pour les unités navales d'assaut en mer. Rendements +100% pour le pillage de routes commerciales. Rendements -50% pour les routes commerciales.</Text>
-		</Replace>
-		<Replace Tag="LOC_POLICY_MARKET_ECONOMY_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_GOLD] Or +1, [ICON_SCIENCE] Science +2 et [ICON_CULTURE] Culture +2 par ressource de luxe ou stratégique aménagée à destination d'une [ICON_TRADEROUTE] route commerciale internationale.</Text>
-		</Replace>
-		<Replace Tag="LOC_POLICY_RAID_EXPANSION1_ALT_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_PILLAGED] Rendements +50% pour les pillages et assauts côtiers.</Text>
-		</Replace>
-		<Replace Tag="LOC_POLICY_TOTAL_WAR_EXPANSION1_ALT_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_PILLAGED] Rendements +50 % pour les pillages, les assauts côtiers et le pillage des [ICON_TRADEROUTE] routes commerciales.</Text>
-		</Replace>
-		<Replace Tag="LOC_POLICY_CRAFTSMEN_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_DISTRICT_INDUSTRIAL_ZONE]Bonus de proximité +100% pour les Zones industrielles.</Text>
-		</Replace>
-		<Replace Tag="LOC_POLICY_TOWN_CHARTERS_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_DISTRICT_COMMERCIAL_HUB] Bonus de proximité +100% pour les Plateformes commerciales.</Text>
-		</Replace>
-		<Replace Tag="LOC_POLICY_NAVAL_INFRASTRUCTURE_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_DISTRICT_HARBOR] Bonus de proximité +100% pour les Ports.</Text>
-		</Replace>
 		<Replace Tag="LOC_POLICY_NATURAL_PHILOSOPHY_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_DISTRICT_CAMPUS] Bonus de proximité +100% pour les Campus.</Text>
-		</Replace>
-		<Replace Tag="LOC_POLICY_AESTHETICS_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_DISTRICT_THEATER] Bonus de proximité +100% de les Places du théâtre.</Text>
 		</Replace>
 		<Replace Tag="LOC_POLICY_SCRIPTURE_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_DISTRICT_HOLYSITE] Bonus de proximité +100% pour les Lieux saints.</Text>
 		</Replace>
-		<Replace Tag="LOC_POLICY_FIVE_YEAR_PLAN_DESCRIPTION" Language="fr_FR">
-			<Text>[ICON_DISTRICT_CAMPUS][ICON_DISTRICT_INDUSTRIAL_ZONE] Bonus de proximité +100% pour les Zones industrielles et les Campus.</Text>
+		<Replace Tag="LOC_POLICY_NAVAL_INFRASTRUCTURE_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_DISTRICT_HARBOR] Bonus de proximité +100% pour les Ports.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_SERFDOM_DESCRIPTION" Language="fr_FR">
+			<Text>Les Bâtisseurs nouvellement formés ont 2 [ICON_CHARGES] charges supplémentaires.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_CIVIL_PRESTIGE_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_AMENITIES] Activités +1 et [ICON_HOUSING] Habitations +2 pour les villes avec un [ICON_GOVERNOR] gouverneur établi possédant au moins deux promotions.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_TRADE_CONFEDERATION_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_SCIENCE] Science +1 et [ICON_CULTURE] Culture +1 pour les [ICON_TRADEROUTE] routes commerciales internationales.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_AESTHETICS_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_DISTRICT_THEATER] Bonus de proximité +100% pour les Places du théâtre.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_MEDINA_QUARTER_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_HOUSING] Habitations +1 dans toutes les villes pour chaque [ICON_DISTRICT] quartier spécialisé.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_TOWN_CHARTERS_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_DISTRICT_COMMERCIAL_HUB] Bonus de proximité +100% pour les Plateformes commerciales.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_GOTHIC_ARCHITECTURE_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +15% pour les merveilles des ères antique, classique, médiévale et de la Renaissance.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_RELIGIOUS_ORDERS_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_RELIGION] Puissance religieuse +5 pour toutes les unités religieuses en combat théologique.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_SIMULTANEUM_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_FAITH] Foi des bâtiments des Lieux saints : +50% si la ville compte au moins 13 [ICON_CITIZEN] Citoyens, +50% si le quartier a un bonus de proximité d'au moins +3.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_TRIANGULAR_TRADE_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_GOLD] Or +4 et [ICON_FAITH] Foi +1 pour les [ICON_TRADEROUTE] routes commerciales.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_RATIONALISM_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_SCIENCE] Science des bâtiments des Campus : +50% si la ville compte au moins 13 [ICON_CITIZEN] Citoyens, +50% si le quartier a un bonus de proximité d'au moins +3.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FREE_MARKET_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_GOLD] Or des bâtiments des Plateformes commerciales : +50% si la ville compte au moins 13 [ICON_CITIZEN] Citoyens, +50% si le quartier a un bonus de proximité d'au moins +4.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_LIBERALISM_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_AMENITIES] Activités +1 pour les villes possédant au moins 2 [ICON_DISTRICT] quartiers spécialisés.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_PUBLIC_WORKS_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +30% pour les Bâtisseurs. Les Bâtisseurs nouvellement formés ont 2 [ICON_CHARGES] charges supplémentaires.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_SKYSCRAPERS_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +15% pour toutes les merveilles.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_GRAND_OPERA_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_CULTURE] Culture des bâtiments des Places du théâtre : +50% si la ville compte au moins 13 [ICON_CITIZEN] Citoyens, +50% si le quartier a un bonus de proximité d'au moins +3.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_PUBLIC_TRANSPORT_DESCRIPTION_XP2" Language="fr_FR">
+      		<Text>[ICON_FOOD] Nourriture +3 et [ICON_PRODUCTION] Production +1 pour les Quartiers résidentiels d'un Attrait charmant (+4 et +2 si le quartier est époustouflant). [ICON_GOLD] Or +1 pour tous les Quartiers résidentiels.</Text>
+    	</Replace>
+		<Replace Tag="LOC_POLICY_EXPROPRIATION_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +50% pour les Colons. Coût d'achat de cases réduit de 20%.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_MARKET_ECONOMY_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_GOLD] Or +1, [ICON_SCIENCE] Science +2 et [ICON_CULTURE] Culture +2 par ressource de luxe ou stratégique aménagée à destination d'une [ICON_TRADEROUTE] route commerciale internationale.</Text>
 		</Replace>
 		<Replace Tag="LOC_POLICY_ECONOMIC_UNION_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_DISTRICT_COMMERCIAL_HUB][ICON_DISTRICT_HARBOR] Bonus de proximité +100% pour les Plateformes commerciales et les Ports.</Text>
-		</Replace>		
+		</Replace>
+		<Replace Tag="LOC_POLICY_FIVE_YEAR_PLAN_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_DISTRICT_INDUSTRIAL_ZONE][ICON_DISTRICT_CAMPUS] Bonus de proximité +100% pour les Campus et les Zones industrielles.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_NEW_DEAL_DESCRIPTION_XP2" Language="fr_FR">
+			<Text>[ICON_AMENITIES] Activités +2 et [ICON_HOUSING] Habitations +4 pour les villes possédant au moins 3 [ICON_DISTRICT] quartiers spécialisés.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_COLLECTIVIZATION_DESCRIPTION_XP2" Language="fr_FR">
+			<Text>[ICON_FOOD] Nourriture +4 et [ICON_PRODUCTION] Production +4 pour vos [ICON_TRADEROUTE] routes commerciales intérieures. [ICON_GOLD] Or +4 pour toutes les routes commerciales.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_HERITAGE_TOURISM_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_TOURISM] Tourisme +100% pour les [ICON_GREATWORK_LANDSCAPE] chefs-d'œuvre artistiques et les [ICON_GREATWORK_ARTIFACT] artefacts.</Text>
+		</Replace>
 		<Replace Tag="LOC_POLICY_SPORTS_MEDIA_DESCRIPTION" Language="fr_FR">
 			<Text>[ICON_DISTRICT_THEATER] Bonus de proximité +100% pour les Places du théâtre, et [ICON_AMENITIES] Activités +1 pour les stades.</Text>
 		</Replace>
+		<Replace Tag="LOC_POLICY_SATELLITE_BROADCASTS_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_TOURISM] Tourisme +200% pour les [ICON_GREATWORK_MUSIC] chefs-d'œuvre musicaux.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_ECOMMERCE_EXPANSION1_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +2 et [ICON_GOLD] Or +5 pour les [ICON_TRADEROUTE] routes commerciales.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_ONLINE_COMMUNITIES_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_TOURISM] Tourisme +50 % envers les civilisations auxquelles vous envoyez une [ICON_TRADEROUTE] route commerciale.</Text>
+		</Replace>
 
+		<!-- == DIPLOMATIC - DIPLOMATIQUE == -->
+		<Replace Tag="LOC_POLICY_CHARISMATIC_LEADER_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_INFLUENCEPERTURN] Points d'influence +2 par tour.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_DIPLOMATIC_LEAGUE_DESCRIPTION" Language="fr_FR">
+			<Text>Le premier [ICON_ENVOY] émissaire que vous envoyez dans une Cité-état compte pour deux.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_PRAETORIUM_DESCRIPTION" Language="fr_FR">
+			<Text>Loyauté +4 par tour dans les villes où est installé un [ICON_GOVERNOR] gouverneur.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_MERCHANT_CONFEDERATION_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_GOLD] Or +1 pour chaque [ICON_ENVOY] émissaire dans une Cité-état.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_COLONIAL_OFFICES_DESCRIPTION" Language="fr_FR">
+			<Text>Vitesse de croissance +15 % pour les villes hors du continent de votre [ICON_CAPITAL] Capitale.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_MACHIAVELLIANISM_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +50% pour les espions. Opérations d'espionnage 25% plus rapides.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_WISSELBANKEN_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_FOOD] Nourriture +2 et [ICON_PRODUCTION] Production +2 pour les [ICON_TRADEROUTE] routes commerciales avec une ville alliée. Les points d'alliance avec tous les alliés augmentent de 0,25 point en plus par tour.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_COLONIAL_TAXES_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_GOLD] Or +25% dans les villes hors du continent de votre [ICON_CAPITAL] Capitale.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_RAJ_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_GOLD] Or +2, [ICON_SCIENCE] Science +2, [ICON_CULTURE] Culture +2 et [ICON_FAITH] Foi +2 pour chaque Cité-état dont vous êtes le suzerain.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_RAJ_DESCRIPTION_XP2" Language="fr_FR">
+			<Text>[ICON_GOLD] Or +2, [ICON_SCIENCE] Science +2, [ICON_CULTURE] Culture +2 et [ICON_FAITH] Foi +2 pour chaque Cité-état dont vous êtes le suzerain. [ICON_GOLD] Or +2 pour les [ICON_TRADEROUTE] routes commerciales avec des Cités-états.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_GUNBOAT_DIPLOMACY_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_INFLUENCEPERTURN] Points d'influence +4 par tour. Libre passage avec toutes les Cités-états. </Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_NUCLEAR_ESPIONAGE_DESCRIPTION" Language="fr_FR">
+			<Text>Les espions qui volent un [ICON_TECHBOOSTED] Eurêka ! sans se faire repérer gagnent un autre [ICON_TECHBOOSTED] Eurêka !</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_CRYPTOGRAPHY_DESCRIPTION" Language="fr_FR">
+			<Text>Niveau de l'espion ennemi réduit de 2 sur vos terres. Celui de votre espion augmente de 1 pour les opérations offensives.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_CONTAINMENT_DESCRIPTION" Language="fr_FR">
+			<Text>Chaque [ICON_ENVOY] émissaire envoyé dans une Cité-état compte pour deux si son suzerain a un [ICON_GOVERNMENT] gouvernement différent du vôtre.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_MUSIC_CENSORSHIP_DESCRIPTION" Language="fr_FR">
+			<Text>Les groupes de rock des autres joueurs n'ont pas le droit de pénétrer sur votre territoire. [ICON_AMENITIES] Activités -1 dans toutes vos villes possédant au moins 10 [ICON_Citizen] Citoyens.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_INTERNATIONAL_SPACE_AGENCY_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_SCIENCE] Science +5% pour chaque Cité-état dont vous êtes le suzerain.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_COLLECTIVE_ACTIVISM_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_CULTURE] Culture +5% pour chaque Cité-état dont vous êtes le suzerain.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_COMMUNICATIONS_OFFICE_DESCRIPTION" Language="fr_FR">
+			<Text>Loyauté +2 par tour par [ICON_GOVERNOR] gouverneur et par promotion qu'il possède dans sa ville.</Text>
+		</Replace>
 
+		<!-- == WILDCARD - JOKER == -->
+		<Replace Tag="LOC_POLICY_STRATEGOS_DESCRIPTION" Language="fr_FR">
+			<Text>Points de [ICON_GREATGENERAL] Général illustre +2 par tour.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_INSPIRATION_DESCRIPTION" Language="fr_FR">
+			<Text>Points de [ICON_GREATSCIENTIST] Savant illustre +2 par tour.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_REVELATION_DESCRIPTION" Language="fr_FR">
+			<Text>Points de [ICON_GREATPROPHET] Prophète illustre +2 par tour.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_LITERARY_TRADITION_DESCRIPTION" Language="fr_FR">
+			<Text>Points [ICON_GREATWRITER] d'Écrivain illustre +2 par tour.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_NAVIGATION_DESCRIPTION" Language="fr_FR">
+			<Text>Points [ICON_GREATADMIRAL] d'Amiral illustre +2 par tour.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_TRAVELING_MERCHANTS_DESCRIPTION" Language="fr_FR">
+			<Text>Points de [ICON_GREATMERCHANT] Marchand illustre +2 par tour.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_INVENTION_DESCRIPTION" Language="fr_FR">
+			<Text>Points [ICON_GREATENGINEER] d'Ingénieur illustre +2 par tour.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FRESCOES_DESCRIPTION" Language="fr_FR">
+			<Text>Points [ICON_GREATARTIST] d'Artiste illustre +2 par tour.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_SYMPHONIES_DESCRIPTION" Language="fr_FR">
+			<Text>Points de [ICON_GREATMUSICIAN] Musicien illustre +4 par tour.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_MILITARY_ORGANIZATION_DESCRIPTION" Language="fr_FR">
+			<Text>Points de [ICON_GREATGENERAL] Général illustre +4 par tour.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_LAISSEZ_FAIRE_DESCRIPTION" Language="fr_FR">
+			<Text>Points de [ICON_GREATMERCHANT] Marchand illustre +4 par tour.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_NOBEL_PRIZE_DESCRIPTION_XP2" Language="fr_FR">
+			<Text>Points de [ICON_GREATSCIENTIST] Savant illustre +2 par tour pour chaque université et +4 par tour pour chaque laboratoire de recherches. Points [ICON_GREATENGINEER] d'Ingénieur illustre +2 par tour pour chaque usine et +4 par tour pour chaque centrale électrique.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FINEST_HOUR_DESCRIPTION_XP2" Language="fr_FR">
+			<Text>[ICON_Strength] Puissance de combat +5 pour les unités dans votre territoire ou adjacentes à celui-ci.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_MARTIAL_LAW_DESCRIPTION_XP2" Language="fr_FR">
+			<Text>L'usure de la guerre progresse 25% moins vite. Loyauté +4 par tour pour les villes possédant une unité en garnison.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_DEFENSE_OF_MOTHERLAND_DESCRIPTION_XP2" Language="fr_FR">
+			<Text>Aucune usure de la guerre ressentie en cas de combat sur votre territoire. [ICON_PRODUCTION] Production +100 % pour les unités de soutien des ères moderne, atomique et de l'information.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FUTURE_VICTORY_CULTURE_DESCRIPTION" Language="fr_FR">
+			<Text>Votre groupe de rock peut choisir n'importe quelle [ICON_PROMOTION] promotion.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FUTURE_COUNTER_SCIENCE_DESCRIPTION" Language="fr_FR">
+			<Text>Vos espions peuvent choisir n'importe quelle [ICON_PROMOTION] promotion.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FUTURE_VICTORY_SCIENCE_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_RESOURCE_ALUMINUM] Aluminium +3 par tour et [ICON_Power] électricité +3 pour les villes dotées d'un spatioport.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FUTURE_VICTORY_DOMINATION_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_MOVEMENT] PM +1 si l'unité commence son tour en territoire ennemi. [ICON_PRODUCTION] Production +50% pour les robots géants de la mort.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FUTURE_COUNTER_DIPLOMATIC_DESCRIPTION" Language="fr_FR">
+			<Text>Lorsque vous réduisez les points de victoire diplomatique d'un joueur au Congrès mondial, vous récupérez 50% des [ICON_FAVOR] faveurs diplomatiques utilisées. [ICON_FAVOR] Faveurs diplomatiques +1 par tour.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FUTURE_VICTORY_DIPLOMATIC_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_FAVOR] Faveurs diplomatiques +4 par tour.</Text>
+		</Replace>
 
+		<!-- == DARK AGE - ÂGE SOMBRE == -->
+		<Replace Tag="LOC_POLICY_MONASTICISM_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_SCIENCE] Science +75% dans les villes possédant un Lieu saint.[NEWLINE]MAIS : [ICON_CULTURE] Culture -25% dans toutes les villes.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_TWILIGHT_VALOR_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_STRENGTH] Puissance de combat en attaque +5 pour toutes les unités de mêlée (combat rapproché (terrestre et navale), anti-cavalerie, cavalerie légère, cavalerie lourde).[NEWLINE]MAIS : pas de soins hors de votre territoire.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_INQUISITION_DESCRIPTION" Language="fr_FR">
+			<Text>Les inquisitions ne coûtent qu'une charge d'Apôtre. [ICON_RELIGION] Puissance religieuse +15 pour toutes les unités religieuses en terrain allié.[NEWLINE]MAIS : [ICON_SCIENCE] Science -25% dans toutes les villes.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_ISOLATIONISM_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_FOOD] Nourriture +2 et [ICON_PRODUCTION] Production +2 pour les routes internes.[NEWLINE]MAIS : impossible de former/acheter des Colons ni de fonder des villes.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_LETTERS_OF_MARQUE_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +100% et [ICON_MOVEMENT] PM +2 pour les unités navales d'assaut en mer. Rendements +100% pour le pillage de routes commerciales.[NEWLINE]MAIS : rendements -50% pour les routes commerciales.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_ROBBER_BARONS_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_GOLD] Or +50% dans les villes dotées d'une bourse. [ICON_PRODUCTION] Production +25% dans les villes dotées d'une usine.[NEWLINE]MAIS : [ICON_AMENITIES] Activités -2 dans toutes les villes.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_ELITE_FORCES_DESCRIPTION" Language="fr_FR">
+			<Text>Expérience au combat +100% pour toutes les unités.[NEWLINE]MAIS : coût d'entretien +2 pour les unités militaires et les espions.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_COLLECTIVISM_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_FOOD] Nourriture +1 pour les fermes. [ICON_HOUSING] Habitations +2 pour toutes les villes. Bonus de proximité +100% pour les Zones industrielles.[NEWLINE]MAIS : génération de points de [ICON_GREATPERSON] Personnages illustres -50%.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_ROGUE_STATE_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +50% pour les projets de programme nucléaire et les armes atomiques [NEWLINE]MAIS : [ICON_INFLUENCEPERTURN] Point d'influence -100%.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_FLOWER_POWER_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_TOURISM] Tourisme généré par les concerts +100% envers les civilisations qui ne sont pas en guerre.[NEWLINE]MAIS : vous perdez 100% de votre [ICON_PRODUCTION] Production et le coût d'achat sera +100% pour les unités autres que les groupes de rock.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_AUTOMATED_WORKFORCE_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +20% pour les projets de vos villes.[NEWLINE]MAIS : [ICON_AMENITIES] Activités -1 et loyauté -5 par tour pour toutes les villes.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_CYBER_WARFARE_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_STRENGTH] Puissance de combat +10 contre les unités des ères de l'information et future.[NEWLINE]MAIS : les [ICON_STAT_GRIEVANCE] griefs contre vous ne diminuent pas.</Text>
+		</Replace>
+		<Replace Tag="LOC_POLICY_DISINFORMATION_CAMPAIGN_DESCRIPTION" Language="fr_FR">
+			<Text>[ICON_FAVOR] Faveurs diplomatiques +3 par tour pour chaque centre de diffusion.[NEWLINE]MAIS : [ICON_SCIENCE] Science -10% et [ICON_CULTURE] Culture -10% dans toutes les villes.</Text>
+		</Replace>
+	
+	
+	
 		<!-- === GREAT PEOPLE - PERSONNAGES ILLUSTRES === -->
 		<!-- == GREAT GENERAL == -->
 		<Replace Tag="LOC_GREATPERSON_BOUDICA_ACTIVE" Language="fr_FR">
@@ -3572,12 +3880,7 @@
 
 
 		<!-- === ALLIANCES === -->
-		<Replace Tag="LOC_ALLIANCE_LV1_RESEARCH_EFFECT_2" Language="fr_FR">
-			<Text>[ICON_SCIENCE] Science +2 des [ICON_TRADEROUTE] routes commerciales de votre allié.</Text>
-		</Replace>
-		<Replace Tag="LOC_ALLIANCE_LV1_CULTURAL_EFFECT_2" Language="fr_FR">
-			<Text>[ICON_CULTURE] Culture +2 des [ICON_TRADEROUTE] routes commerciales de votre allié.</Text>
-		</Replace>
+		<!-- == ECONOMIC - ÉCONOMIQUE == -->
 		<Replace Tag="LOC_ALLIANCE_LV1_ECONOMIC_EFFECT_1" Language="fr_FR">
 			<Text>[ICON_GOLD] Or +6 pour les [ICON_TRADEROUTE] routes commerciales vers votre allié.</Text>
 		</Replace>
@@ -3587,17 +3890,67 @@
 		<Replace Tag="LOC_ALLIANCE_LV2_ECONOMIC_EFFECT_1" Language="fr_FR">
 			<Text>[ICON_INFLUENCEPERTURN] Points d'influence +1 par tour par Cité-état dont votre allié est suzerain.</Text>
 		</Replace>
-		<Replace Tag="LOC_ALLIANCE_LV1_RELIGIOUS_EFFECT_1" Language="fr_FR">
-			<Text>[ICON_FAITH] Foi +4 pour les [ICON_TRADEROUTE] routes commerciales vers votre allié.</Text>
+		<Replace Tag="LOC_ALLIANCE_LV3_ECONOMIC_EFFECT" Language="fr_FR">
+			<Text>Les bonus de suzerain sont partagés entre vous et votre allié.</Text>
 		</Replace>
-		<Replace Tag="LOC_ALLIANCE_LV1_RELIGIOUS_EFFECT_2" Language="fr_FR">
-			<Text>[ICON_FAITH] Foi +4 des [ICON_TRADEROUTE] routes commerciales de votre allié.</Text>
+
+		<!-- == MILITARY - MILITAIRE == -->
+		<Replace Tag="LOC_ALLIANCE_LV1_MILITARY_EFFECT_1" Language="fr_FR">
+			<Text>[ICON_Strength] Puissance de combat +5 contre les unités des joueurs en guerre contre votre allié et vous.</Text>
 		</Replace>
-		<Replace Tag="LOC_ALLIANCE_LV2_RELIGIOUS_EFFECT_1" Language="fr_FR">
-			<Text>[ICON_RELIGION] Puissance de combat théologique +10 contre les religions non-aliées.</Text>
+		<Replace Tag="LOC_ALLIANCE_LV2_MILITARY_EFFECT_1" Language="fr_FR">
+			<Text>[ICON_PRODUCTION] Production +15% pour les unités militaires lorsque votre allié ou vous êtes en guerre.</Text>
 		</Replace>
 		<Replace Tag="LOC_ALLIANCE_LV3_MILITARY_EFFECT_1" Language="fr_FR">
 			<Text>Les unités commencent avec une [ICON_PROMOTION] promotion gratuite.</Text>
+		</Replace>
+
+		<!-- == RESEARCH - SCIENTIFIQUE == -->
+		<Replace Tag="LOC_ALLIANCE_LV1_RESEARCH_EFFECT_1" Language="fr_FR">
+			<Text>[ICON_SCIENCE] Science +2 pour les [ICON_TradeRoute] routes commerciales vers les villes de votre allié.</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV1_RESEARCH_EFFECT_2" Language="fr_FR">
+			<Text>[ICON_SCIENCE] Science +2 des [ICON_TRADEROUTE] routes commerciales de votre allié.</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV2_RESEARCH_EFFECT_1" Language="fr_FR">
+			<Text>Tous les 30 tours (en vitesse normale), vous débloquez un [ICON_TechBoosted] Eurêka ! pour une technologie que votre allié a découverte ou améliorées.</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV3_RESEARCH_EFFECT_1" Language="fr_FR">
+			<Text>[ICON_SCIENCE] Science +10% si votre allié ou vous-même étudiez une technologie déjà découverte par l'autre ou que vous étudiez la même technologie.</Text>
+		</Replace>
+
+		<!-- == CULTURAL - CULTURELLE == -->
+		<Replace Tag="LOC_ALLIANCE_LV1_CULTURAL_EFFECT_1" Language="fr_FR">
+			<Text>[ICON_Culture] Culture +2 pour les [ICON_TradeRoute] routes commerciales vers les villes de votre allié.</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV1_CULTURAL_EFFECT_2" Language="fr_FR">
+			<Text>[ICON_CULTURE] Culture +2 des [ICON_TRADEROUTE] routes commerciales de votre allié.</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV2_CULTURAL_EFFECT_1" Language="fr_FR">
+			<Text>Tous les quartiers d'une ville reliée à la ville d'un allié par une route commerciale octroient +1 points de [ICON_GREATPERSON] Personnage illustre.</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV3_CULTURAL_EFFECT_1" Language="fr_FR">
+			<Text>Vous gagnez du [ICON_TOURISM] Tourisme égal à 20% du [ICON_TOURISM] Tourisme produit par les villes de votre allié.</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV3_CULTURAL_EFFECT_2" Language="fr_FR">
+			<Text>Vous gagnez de la [ICON_CULTURE] Culture égale à 10% de la [ICON_CULTURE] Culture produite par les villes de votre allié.</Text>
+		</Replace>
+
+		<!-- == RELIGIOUS - RELIGIEUSE == -->
+		<Replace Tag="LOC_ALLIANCE_LV1_RELIGIOUS_EFFECT_1" Language="fr_FR">
+			<Text>[ICON_FOOD] Nourriture +1 et [ICON_FAITH] Foi +4 pour les [ICON_TRADEROUTE] routes commerciales vers votre allié.</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV1_RELIGIOUS_EFFECT_2" Language="fr_FR">
+			<Text>[ICON_FOOD] Nourriture +1 et [ICON_FAITH] Foi +4 des [ICON_TRADEROUTE] routes commerciales de votre allié.</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV2_RELIGIOUS_EFFECT_1" Language="fr_FR">
+			<Text>[ICON_RELIGION] Puissance de combat théologique +10 contre les [ICON_RELIGION] religions non-aliées.</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV3_RELIGIOUS_EFFECT_1" Language="fr_FR">
+			<Text>[ICON_FAITH] Foi +1 pour chacun de vos [ICON_CITIZEN] Citoyens ayant adopté la [ICON_RELIGION] religion de votre allié.</Text>
+		</Replace>
+		<Replace Tag="LOC_ALLIANCE_LV3_RELIGIOUS_EFFECT_2" Language="fr_FR">
+			<Text>Vous recevez un bonus de pression religieuse dans chacune des villes ne comportant aucun fidèle à la [ICON_RELIGION] religion de votre allié.</Text>
 		</Replace>
 
 
@@ -3628,10 +3981,10 @@
 			<Text>La ressource de luxe choisie n'octroie pas [ICON_AMENITIES] d'Activité.</Text>
 		</Replace>
 		<Replace Tag="LOC_WORLD_CONGRESS_BUFF_PRODUCTION_YIELD_DESC" Language="fr_FR">
-			<Text>Le coût en Production ou d'achat des unités militaires est réduit de 50% jusqu'au prochain Congrès mondial.</Text>
+			<Text>Le coût en Production ou d'achat des unités militaires est réduit de 25% jusqu'au prochain Congrès mondial.</Text>
 		</Replace>
 		<Replace Tag="LOC_WORLD_CONGRESS_BAN_PRODUCTION_YIELD_DESC" Language="fr_FR">
-			<Text>Le coût en Production ou d'achat des unités militaires est doublé jusqu'au prochain Congrès mondial.</Text>
+			<Text>Le coût en Production ou d'achat des unités militaires est augmenté de 50% jusqu'au prochain Congrès mondial.</Text>
 		</Replace>
 		<Replace Tag="LOC_WORLD_CONGRESS_BUFF_ARMS_CONTROL_DESC" Language="fr_FR">
 			<Text>Les armes de destruction massive de tous les joueurs sont réglées sur le niveau de celles du joueur ciblé.</Text>
@@ -3697,7 +4050,7 @@
 			<Text>Coût en [ICON_PRODUCTION] Production -50% pour ce type de bâtiment.</Text>
 		</Replace>
 		<Replace Tag="LOC_WORLD_CONGRESS_BAN_BUILDING_DESC" Language="fr_FR">
-			<Text>Interdit la production de bâtiments de ce type.</Text>
+			<Text>Interdit la Production de bâtiments de ce type.</Text>
 		</Replace>
 		<Replace Tag="LOC_WORLD_CONGRESS_FAVOR_FROM_TRADE_AND_ENVOYS_WITH_MINORS_DESC" Language="fr_FR">
 			<Text>Type de rendement de la Cité-état +100% pour les [ICON_TRADEROUTE] routes commerciales à destination de ce type de Cité-état.</Text>
@@ -4090,7 +4443,6 @@
 		<Row Tag="LOC_BBG_FRONT_BBCC_SETTING_1_DESC" Language="fr_FR">
 			<Text>Activé sur les Capitales uniquement</Text>
 		</Row>
-		
 		<Row Tag="BBCC_SETTING_YIELD_NAME" Language="fr_FR">
 			<Text>[COLOR:92,216,92]BCY : Rendements de Centre-ville[ENDCOLOR]</Text>
 		</Row>


### PR DESCRIPTION
all cards
Preserve, Grove : +1 Food and Faith if the tile is Charming or less, +1 Culture if the tile is Charming and +2 Food/Faith/Culture if the tile is Breathtaking.
Preserve, Sanctuary : +1 Science and Gold if the tile is Charming or less, +1 Production if the tile is Charming and +2 Science/Gold/Production if the tile is Breathtaking.
Theocracy : Faith discount nerf reverted (back to 15%)
Egypt : District Production bonus on river reduced to 20% (from 25).
Grande Armée: fix the text (ère moderne)
Autocracy : Monument gives +1 Production and +1 Food if the city has a specialty district (also added to autocratic heritage)
Fisheries : +1 Housing (from 0.5).
Magnus : +2 Production and +2 Food for internal Traderoute swapped.
Tithe : +3 golds per city converted (from 2).
Mvemba :  religious bonus (bugged) replaced by "+1gold +0.2 culture per converted pop" in your cities
China, Qin-Shi (Mandate of Heaven) : +1 Food per wonder built in the city.
Kongo, MBande : Civilian units now ignore forests.
Germany : Commercial Hub now culture bomb.
Mali : Production malus to 15% (from 20%).
Arabia, Saladin (Sultan) : -1 Gold maintenance for all military units.
Macedon : Bonus red card removed.
Sumeria : Ziggurat Faith delayed to Early Empire.
Gandhi : Reduce war weariness from 100% to 50%
Hungary : Bonus green card removed.
Caguana : Bateys get +1 Production per adjacent strategics, +1 Gold per adjacent luxury and are now buildable on hills.
Rapa Nui : Moai can now be placed adjacent to wood or rainforest.
Hattusa : +2 of each discovered strategics, even if you have one improved.
La Venta : Colossal Heads get +1 base Food and Housing.
Jerusalem : +1 Gold for cities with Holy Sites.
Mogadiscio : +2 golds per traderoutes (same as Bandar, not a typo).
Bandar Brunei : +2 golds per traderoutes.
Samarkand : Trading Dome now gives +1 Production per Traderoute.
Venice : 2 golds per lux in destination city (from 1).
Granada : Alcazars get +1 base Production and +1 additional culture per adjacent Encampment.
Armagh : Monasteries get +1 base Food and +1 Faith per adjacent district at Reformed Church (instead of +1 faith every 2 adjacent districts)
Auckland : Now only works on improved tiles.
Singapore : Previous bonus removed, +2 Production per external Traderoute.
Mexico City : Aqueducts grant 1 amenities.
Cardiff : Harbor buildings get +1 Production and Gold.
Religious : +1 Food per Traderoute