### PR TITLE
Amani Trade Route Yields Display using ui replacement 

### DIFF
--- a/BetterBalancedGame.modinfo
+++ b/BetterBalancedGame.modinfo
@@ -1028,7 +1028,6 @@
 			<LuaReplace>ui/replacements/worldrankings_bbg.lua</LuaReplace>
 			</Properties>
 		</ReplaceUIScript>
-		<!--
 		<ReplaceUIScript id="BBG_UnitPanel_XP2">
 			<Criteria>XP2</Criteria>
 			<Properties>
@@ -1037,6 +1036,7 @@
 				<LuaReplace>ui/replacements/unitpanel_bbg.lua</LuaReplace>
 			</Properties>
 		</ReplaceUIScript>
+		<!--
 		<ReplaceUIScript id="productionpanel_bbg">
 			<Criteria>BBGTS_ProductionPanel_BBG_Expansion2</Criteria>
 			<Properties>
@@ -1307,7 +1307,7 @@
 		<File>ui/replacements/endgamemenu.xml</File>
 		<!--<File>ui/replacements/productionpanel_bbg.lua</File>-->
 		<File>ui/replacements/tradeoverview_bbg.lua</File>
-		<!--<File>ui/replacements/unitpanel_bbg.lua</File>-->
+		<File>ui/replacements/unitpanel_bbg.lua</File>
 		<File>ui/replacements/tradesupport.lua</File>
 		<File>ui/replacements/compatibility/traderoutechooser.lua</File>
 		<File>ui/replacements/compatibility/tradeoverview.lua</File>

--- a/ui/replacements/tradesupport.lua
+++ b/ui/replacements/tradesupport.lua
@@ -101,6 +101,39 @@ function GetYieldsForRoute(pOriginCity:table, pDestinationCity:table, bReturnDes
 		end
 	end
 
+	-- BBG Corrects Amani owner only trade route bonuses to show on Trader Unit Panel
+
+    local isCityState:boolean = false;
+    local governorsAssignedToCity = pDestinationCity:GetAllAssignedGovernors();
+    -- print(#governorsAssignedToCity);
+    local playerId = Game.GetLocalPlayer();
+    -- print('PlayerId:');
+    -- print(playerID);
+    for i, j in ipairs(governorsAssignedToCity) do
+        if j:GetOwner() == playerId then
+            -- print('CS Amani Governor belongs to player');
+            -- check its a city state
+            for i, pCityState in ipairs(PlayerManager.GetAliveMinors()) do
+		        if pCityState:GetID() == destOwnerID then
+			        isCityState = true;
+			        break;
+		        end
+	        end
+	        -- need this check to make sure its not Ibrahim (Ottoman governor)
+            if j:GetName() == 'LOC_GOVERNOR_THE_AMBASSADOR_NAME' and j:IsEstablished() and isCityState then
+                -- print('Amani fully established, adding Messenger promo yields.')
+                kRouteYields[1] = kRouteYields[1] + 2;
+                kRouteYields[2] = kRouteYields[2] + 2;
+                --[[if j:HasPromotion(DB.MakeHash('GOVERNOR_PROMOTION_AMBASSADOR_FOREIGN_INVESTOR')) then
+                	kRouteYields[1] = kRouteYields[1] + 1;
+                    kRouteYields[2] = kRouteYields[2] + 1;
+                    kRouteYields[3] = kRouteYields[1] + 3;
+                    -- print('Amani Promotion recognised, added Foreign Investor yields to display');
+                end --]]
+            end
+        end
+    end
+
 	-- Add the yields together and return the result
 	for yieldIndex=1, #kRouteYields, 1 do
 

--- a/ui/replacements/unitpanel_bbg.lua
+++ b/ui/replacements/unitpanel_bbg.lua
@@ -1,4 +1,35 @@
 include "UnitPanel_Expansion2"
+
+-- Vanilla Function ===========================================================================
+function TradeUnitView( viewData:table )
+	if viewData.IsTradeUnit then
+		local hideTradeYields:boolean = true;
+		local originPlayer:table = Players[Game.GetLocalPlayer()];
+		local originCities:table = originPlayer:GetCities();
+		for _, city in originCities:Members() do
+			local outgoingRoutes:table = city:GetTrade():GetOutgoingRoutes();
+			for i,route in ipairs(outgoingRoutes) do
+				if viewData.UnitID == route.TraderUnitID then
+					-- Add Origin Yields
+					Controls.TradeResourceList:DestroyAllChildren();
+					for j,yieldInfo in pairs(route.OriginYields) do
+						if yieldInfo.Amount > 0 then
+							local yieldDetails:table = GameInfo.Yields[yieldInfo.YieldIndex];
+							AddTradeResourceEntry(yieldDetails, Round(yieldInfo.Amount,1));
+							hideTradeYields = false;
+						end
+					end
+				end
+			end
+		end
+
+		Controls.TradeYieldGrid:SetHide(hideTradeYields);
+		Controls.TradeUnitContainer:SetHide(false);
+	else
+		Controls.TradeUnitContainer:SetHide(true);
+	end
+end
+
 print("Unitpanel Replacement for BBG")
 --Hungary Huszar Display Override: 
 


### PR DESCRIPTION
Uses base game TradeSupport and UnitPanel to correctly displays the Amani trade route yields for trading to a city where you have her placed. Affects the Trader selection screen, Trade Route overview panel and Trader UnitPanel when Trader in progress.

Tested locally with 5.8, includes commented out changes for second right Amani promotion that was removed.

Tested in Multiplayer Hotseat to make sure Amani's didnt stack or work for other players. No additional UI mods as did not know what was standard, would be happy to update if we needed some compatability. Unsure if network safe but from my lua knowledge it should be.

First commit is just to easily see diff from what the base game does in the function we are replacing. Easy squash.

Attached screenshots of tests:
Test it works
![TradingOnEstablish](https://github.com/user-attachments/assets/a5ffae73-9fa6-4903-9b1f-0f9e1f8f9802)
UnitPanel Check:
![TradingUnitPanelOnEstablish](https://github.com/user-attachments/assets/90c9aa42-4d8c-431f-93e5-9ac00830e7a0)

Test it doesnt work for other players
![TradingBeforeEstablishOTHER](https://github.com/user-attachments/assets/b175d9f9-2be1-4f76-8425-b2b5bd191aae)
UnitPanel Check:
![TradingonUnitPanelNoEstablishOTHER](https://github.com/user-attachments/assets/f8955d1a-1529-4d9a-beb8-7760846171ad)

Test it doesnt work for ally cities with Amani:
![TradingOnEstablishCityEmpireFails](https://github.com/user-attachments/assets/0063f8fb-d846-400b-a84f-201ec5ae727c)

